### PR TITLE
feat: 조건에 따른 상품 ID 목록 조회 API 개발

### DIFF
--- a/src/main/java/com/comehere/ssgserver/common/security/SecurityConfig.java
+++ b/src/main/java/com/comehere/ssgserver/common/security/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
 		http
 				.csrf((csrf) -> csrf.disable())
 				.authorizeHttpRequests((auth) -> auth
-						.requestMatchers("/", "/join").permitAll()
+						.requestMatchers("/", "/join", "/api/v1/**", "/swagger-ui/**").permitAll()
 						.anyRequest().authenticated()
 				)
 				.sessionManagement(

--- a/src/main/java/com/comehere/ssgserver/image/domain/ItemImage.java
+++ b/src/main/java/com/comehere/ssgserver/image/domain/ItemImage.java
@@ -16,10 +16,11 @@ public class ItemImage {
 
 	private Long itemId;
 
-	private String url;
+	private String url; // imageUrl
 
 	private String alt;
 
 	@Column(columnDefinition = "TINYINT")
-	private Short isThumbnail;
+	// private Boolean isThumbnail; // short? -> 0,1 제외 다른 숫자 들어올 여지 있음.. boolean?
+	private Short isThumbnail; // is 사용 안하는게 좋음..
 }

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
@@ -1,7 +1,12 @@
 package com.comehere.ssgserver.item.application;
 
+import java.util.List;
+
 import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
+import com.comehere.ssgserver.item.vo.ItemListReqVO;
 
 public interface ItemService {
 	ItemDetailRespDTO getItemDetail(Long id);
+
+	List<Long> getItemList(ItemListReqVO vo);
 }

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
@@ -1,27 +1,26 @@
 package com.comehere.ssgserver.item.application;
 
-import java.util.Optional;
+import java.util.List;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
 
-import com.comehere.ssgserver.clip.domain.ItemClip;
 import com.comehere.ssgserver.item.domain.Item;
 import com.comehere.ssgserver.item.domain.ItemCalc;
 import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
 import com.comehere.ssgserver.item.infrastructual.ItemCalcRepository;
 import com.comehere.ssgserver.item.infrastructual.ItemRepository;
+import com.comehere.ssgserver.item.vo.ItemListReqVO;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class ItemServiceImpl implements ItemService {
+public class ItemServiceImpl implements ItemService { // 기본 CRUD API 생성하기
 	private final ItemRepository itemRepository;
 	private final ItemCalcRepository itemCalcRepository;
 
 	@Override
-	public ItemDetailRespDTO getItemDetail(Long id) {
+	public ItemDetailRespDTO getItemDetail(Long id) { // 상세정보 / 집계 / 기본정보 API 구분
 		Item item = itemRepository.findById(id)
 				.orElseThrow(() -> new IllegalStateException("존재하지 않는 상품입니다."));
 
@@ -38,5 +37,10 @@ public class ItemServiceImpl implements ItemService {
 				.averageStar(itemCalc.getAverageStar())
 				.reviewCount(itemCalc.getReviewCount())
 				.build();
+	}
+
+	@Override
+	public List<Long> getItemList(ItemListReqVO vo) {
+		return itemRepository.getItemList(vo);
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/domain/Item.java
+++ b/src/main/java/com/comehere/ssgserver/item/domain/Item.java
@@ -9,18 +9,20 @@ import lombok.Getter;
 
 @Entity
 @Getter
-public class Item {
+public class Item { // 필드 설정 추가 + @Builder
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(length = 50, nullable = false)
 	private String name;
 
 	private String code;
 
-	@Column(columnDefinition = "LONGTEXT")
+	@Column(columnDefinition = "LONGTEXT", nullable = false)
 	private String description;
 
+	@Column(nullable = false)
 	private Long price;
 
 	private Integer discountRate;

--- a/src/main/java/com/comehere/ssgserver/item/domain/ItemWithCategory.java
+++ b/src/main/java/com/comehere/ssgserver/item/domain/ItemWithCategory.java
@@ -1,9 +1,12 @@
 package com.comehere.ssgserver.item.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 
 @Entity
@@ -12,6 +15,10 @@ public class ItemWithCategory {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "item_id")
+	private Item item;
 
 	private Integer bigCategory;
 

--- a/src/main/java/com/comehere/ssgserver/item/infrastructual/CustomItemRepository.java
+++ b/src/main/java/com/comehere/ssgserver/item/infrastructual/CustomItemRepository.java
@@ -1,0 +1,9 @@
+package com.comehere.ssgserver.item.infrastructual;
+
+import java.util.List;
+
+import com.comehere.ssgserver.item.vo.ItemListReqVO;
+
+public interface CustomItemRepository {
+	List<Long> getItemList(ItemListReqVO vo);
+}

--- a/src/main/java/com/comehere/ssgserver/item/infrastructual/CustomItemRepositoryImpl.java
+++ b/src/main/java/com/comehere/ssgserver/item/infrastructual/CustomItemRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.comehere.ssgserver.item.infrastructual;
+
+import static com.comehere.ssgserver.item.domain.QItem.*;
+import static com.comehere.ssgserver.item.domain.QItemWithCategory.*;
+
+import java.util.List;
+
+import org.springframework.util.StringUtils;
+
+import com.comehere.ssgserver.item.vo.ItemListReqVO;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomItemRepositoryImpl implements CustomItemRepository {
+	private final JPAQueryFactory query;
+
+	@Override
+	public List<Long> getItemList(ItemListReqVO vo) {
+		return query.select(itemWithCategory.item.id)
+				.from(itemWithCategory)
+				.where(
+						itemNameLike(vo.getSearch()),
+						bigCategoryEq(vo.getBigCategoryId()),
+						middleCategoryEq(vo.getMiddleCategoryId()),
+						smallCategoryEq(vo.getSmallCategoryId())
+				)
+				.fetch();
+	}
+
+	private BooleanExpression itemNameLike(String itemName) {
+		return StringUtils.hasText(itemName) ? item.name.like('%' + itemName + '%') : null;
+	}
+
+	private BooleanExpression bigCategoryEq(Integer bigCategoryId) {
+		return bigCategoryId != null ? itemWithCategory.bigCategory.eq(bigCategoryId) : null;
+	}
+
+	private BooleanExpression middleCategoryEq(Integer middleCategoryId) {
+		return middleCategoryId != null ? itemWithCategory.middleCategory.eq(middleCategoryId) : null;
+	}
+
+	private BooleanExpression smallCategoryEq(Integer smallCategoryId) {
+		return smallCategoryId != null ? itemWithCategory.smallCategory.eq(smallCategoryId) : null;
+	}
+}

--- a/src/main/java/com/comehere/ssgserver/item/infrastructual/ItemRepository.java
+++ b/src/main/java/com/comehere/ssgserver/item/infrastructual/ItemRepository.java
@@ -1,10 +1,8 @@
 package com.comehere.ssgserver.item.infrastructual;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.comehere.ssgserver.item.domain.Item;
-import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
 
-public interface ItemRepository extends JpaRepository<Item, Long> {
+public interface ItemRepository extends JpaRepository<Item, Long>, CustomItemRepository {
 }

--- a/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
+++ b/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
@@ -1,5 +1,7 @@
 package com.comehere.ssgserver.item.presentation;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.comehere.ssgserver.item.application.ItemService;
 import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
+import com.comehere.ssgserver.item.vo.ItemListReqVO;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,5 +26,11 @@ public class ItemController {
 	@Operation(summary = "상품 상세정보 API", description = "상품 상세정보 조회")
 	public ItemDetailRespDTO itemDetail(@PathVariable("id") Long id) {
 		return itemService.getItemDetail(id);
+	}
+
+	@GetMapping
+	@Operation(summary = "상품 목록(ID) 조회 API", description = "조건에 맞는 상품 목록 조회")
+	public List<Long> getItemList(ItemListReqVO vo) {
+		return itemService.getItemList(vo);
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/vo/ItemListReqVO.java
+++ b/src/main/java/com/comehere/ssgserver/item/vo/ItemListReqVO.java
@@ -1,0 +1,17 @@
+package com.comehere.ssgserver.item.vo;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ItemListReqVO {
+	private String search;
+
+	private Integer bigCategoryId;
+
+	private Integer middleCategoryId;
+
+	private Integer smallCategoryId;
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #21 

## 📝작업 내용

> 조건에 맞는 상품 목록 

- 모든 상품 조회 : `/items`
- 특정 카테고리의 상품 조회 : `/items?big(/middle/small)CategoryId={id}`
- 특정 검색어를 포함한 상품 조회 : `/items?search={search}`

### 스크린샷 (선택)
1. 상품명에 `a`가 포함된 상품 ID 목록
![image](https://github.com/ComehereTeam/ssg-server/assets/131592978/d8aa715f-fd38-4bdf-a1d5-6686e7ed55a5)

2. 1 + 대 카테고리 id가 2번인 상품 ID 목록
![image](https://github.com/ComehereTeam/ssg-server/assets/131592978/d1f13525-ebc5-416b-827d-f5fdc84fe9f6)
