### PR TITLE
fix : 상품 상세 조회 API 세분화 작업

### DIFF
--- a/src/main/java/com/comehere/ssgserver/brand/application/BrandService.java
+++ b/src/main/java/com/comehere/ssgserver/brand/application/BrandService.java
@@ -1,0 +1,7 @@
+package com.comehere.ssgserver.brand.application;
+
+import com.comehere.ssgserver.brand.dto.BrandRespDTO;
+
+public interface BrandService {
+	BrandRespDTO getBrand(Long itemId);
+}

--- a/src/main/java/com/comehere/ssgserver/brand/application/BrandServiceImpl.java
+++ b/src/main/java/com/comehere/ssgserver/brand/application/BrandServiceImpl.java
@@ -1,0 +1,25 @@
+package com.comehere.ssgserver.brand.application;
+
+import org.springframework.stereotype.Service;
+
+import com.comehere.ssgserver.brand.domain.Brand;
+import com.comehere.ssgserver.brand.dto.BrandRespDTO;
+import com.comehere.ssgserver.brand.infrastructure.BrandWithItemRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BrandServiceImpl implements BrandService {
+	private final BrandWithItemRepository brandWithItemRepository;
+
+	@Override
+	public BrandRespDTO getBrand(Long itemId) {
+		Brand brand = brandWithItemRepository.findByItemId(itemId).getBrand();
+
+		return BrandRespDTO.builder()
+				.id(brand.getId())
+				.name(brand.getName())
+				.build();
+	}
+}

--- a/src/main/java/com/comehere/ssgserver/brand/domain/Brand.java
+++ b/src/main/java/com/comehere/ssgserver/brand/domain/Brand.java
@@ -1,4 +1,4 @@
-package com.comehere.ssgserver.vender.domain;
+package com.comehere.ssgserver.brand.domain;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/comehere/ssgserver/brand/domain/BrandWithItem.java
+++ b/src/main/java/com/comehere/ssgserver/brand/domain/BrandWithItem.java
@@ -1,4 +1,4 @@
-package com.comehere.ssgserver.vender.domain;
+package com.comehere.ssgserver.brand.domain;
 
 import com.comehere.ssgserver.item.domain.Item;
 
@@ -9,8 +9,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class BrandWithItem {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/comehere/ssgserver/brand/dto/BrandRespDTO.java
+++ b/src/main/java/com/comehere/ssgserver/brand/dto/BrandRespDTO.java
@@ -1,0 +1,12 @@
+package com.comehere.ssgserver.brand.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BrandRespDTO {
+	private Long id;
+
+	private String name;
+}

--- a/src/main/java/com/comehere/ssgserver/brand/infrastructure/BrandWithItemRepository.java
+++ b/src/main/java/com/comehere/ssgserver/brand/infrastructure/BrandWithItemRepository.java
@@ -1,0 +1,12 @@
+package com.comehere.ssgserver.brand.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.comehere.ssgserver.brand.domain.BrandWithItem;
+
+public interface BrandWithItemRepository extends JpaRepository<BrandWithItem, Long> {
+	@Query("select bwi from BrandWithItem bwi join fetch bwi.brand b where bwi.item.id = :itemId")
+	BrandWithItem findByItemId(@Param("itemId") Long itemId);
+}

--- a/src/main/java/com/comehere/ssgserver/brand/presentation/BrandController.java
+++ b/src/main/java/com/comehere/ssgserver/brand/presentation/BrandController.java
@@ -1,0 +1,23 @@
+package com.comehere.ssgserver.brand.presentation;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.comehere.ssgserver.brand.application.BrandService;
+import com.comehere.ssgserver.brand.dto.BrandRespDTO;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class BrandController {
+	private final BrandService brandService;
+
+	@GetMapping("/items/brand/{id}")
+	public BrandRespDTO getBrand(@PathVariable("id") Long itemId) {
+		return brandService.getBrand(itemId);
+	}
+}

--- a/src/main/java/com/comehere/ssgserver/bundle/domain/Bundle.java
+++ b/src/main/java/com/comehere/ssgserver/bundle/domain/Bundle.java
@@ -1,6 +1,6 @@
 package com.comehere.ssgserver.bundle.domain;
 
-import com.comehere.ssgserver.vender.domain.Brand;
+import com.comehere.ssgserver.brand.domain.Brand;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/src/main/java/com/comehere/ssgserver/bundle/domain/Bundle.java
+++ b/src/main/java/com/comehere/ssgserver/bundle/domain/Bundle.java
@@ -1,6 +1,6 @@
 package com.comehere.ssgserver.bundle.domain;
 
-import com.comehere.ssgserver.vender.domain.Vender;
+import com.comehere.ssgserver.vender.domain.Brand;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -19,8 +19,8 @@ public class Bundle {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "vender_id")
-	private Vender vender;
+	@JoinColumn(name = "brand_id")
+	private Brand brand;
 
 	private String name;
 }

--- a/src/main/java/com/comehere/ssgserver/common/security/SecurityConfig.java
+++ b/src/main/java/com/comehere/ssgserver/common/security/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
 		http
 				.csrf((csrf) -> csrf.disable())
 				.authorizeHttpRequests((auth) -> auth
-						.requestMatchers("/", "/join").permitAll()
+						.requestMatchers("/", "/join", "/api/v1/**", "/swagger-ui/**").permitAll()
 						.anyRequest().authenticated()
 				)
 				.sessionManagement(

--- a/src/main/java/com/comehere/ssgserver/image/domain/ItemImage.java
+++ b/src/main/java/com/comehere/ssgserver/image/domain/ItemImage.java
@@ -16,10 +16,11 @@ public class ItemImage {
 
 	private Long itemId;
 
-	private String url;
+	private String url; // imageUrl
 
 	private String alt;
 
 	@Column(columnDefinition = "TINYINT")
-	private Short isThumbnail;
+	// private Boolean isThumbnail; // short? -> 0,1 제외 다른 숫자 들어올 여지 있음.. boolean?
+	private Short isThumbnail; // is 사용 안하는게 좋음..
 }

--- a/src/main/java/com/comehere/ssgserver/image/domain/ItemImage.java
+++ b/src/main/java/com/comehere/ssgserver/image/domain/ItemImage.java
@@ -21,6 +21,5 @@ public class ItemImage {
 	private String alt;
 
 	@Column(columnDefinition = "TINYINT")
-	// private Boolean isThumbnail; // short? -> 0,1 제외 다른 숫자 들어올 여지 있음.. boolean?
-	private Short isThumbnail; // is 사용 안하는게 좋음..
+	private Short thumbnail; // is 사용 안하는게 좋음..
 }

--- a/src/main/java/com/comehere/ssgserver/image/dto/ImageDTO.java
+++ b/src/main/java/com/comehere/ssgserver/image/dto/ImageDTO.java
@@ -12,12 +12,12 @@ public class ImageDTO {
 
 	private String alt;
 
-	private Short isThumbnail;
+	private Boolean thumbnail;
 
 	public ImageDTO(ItemImage ii) {
 		this.imageId = ii.getId();
 		this.url = ii.getUrl();
 		this.alt = ii.getAlt();
-		this.isThumbnail = ii.getIsThumbnail();
+		this.thumbnail = ii.getThumbnail() != 0;
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
@@ -4,9 +4,10 @@ import java.util.List;
 
 import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
 import com.comehere.ssgserver.item.vo.ItemListReqVO;
+import com.comehere.ssgserver.item.vo.ItemListRespVO;
 
 public interface ItemService {
 	ItemDetailRespDTO getItemDetail(Long id);
 
-	List<Long> getItemList(ItemListReqVO vo);
+	ItemListRespVO getItemList(ItemListReqVO vo);
 }

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
@@ -1,7 +1,12 @@
 package com.comehere.ssgserver.item.application;
 
+import java.util.List;
+
 import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
+import com.comehere.ssgserver.item.vo.ItemListReqVO;
 
 public interface ItemService {
 	ItemDetailRespDTO getItemDetail(Long id);
+
+	List<Long> getItemList(ItemListReqVO vo);
 }

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
@@ -1,13 +1,16 @@
 package com.comehere.ssgserver.item.application;
 
-import java.util.List;
-
+import com.comehere.ssgserver.item.dto.ItemCalcRespDTO;
 import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
 import com.comehere.ssgserver.item.vo.ItemListReqVO;
 import com.comehere.ssgserver.item.vo.ItemListRespVO;
 
 public interface ItemService {
 	ItemDetailRespDTO getItemDetail(Long id);
+
+	String getDescription(Long id);
+
+	ItemCalcRespDTO getItemCalc(Long id);
 
 	ItemListRespVO getItemList(ItemListReqVO vo);
 }

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import com.comehere.ssgserver.item.domain.Item;
 import com.comehere.ssgserver.item.domain.ItemCalc;
+import com.comehere.ssgserver.item.dto.ItemCalcRespDTO;
 import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
 import com.comehere.ssgserver.item.infrastructual.ItemCalcRepository;
 import com.comehere.ssgserver.item.infrastructual.ItemRepository;
@@ -19,11 +20,8 @@ public class ItemServiceImpl implements ItemService { // 기본 CRUD API 생성�
 	private final ItemCalcRepository itemCalcRepository;
 
 	@Override
-	public ItemDetailRespDTO getItemDetail(Long id) { // 상세정보 / 집계 / 기본정보 API 구분
+	public ItemDetailRespDTO getItemDetail(Long id) {
 		Item item = itemRepository.findById(id)
-				.orElseThrow(() -> new IllegalStateException("존재하지 않는 상품입니다."));
-
-		ItemCalc itemCalc = itemCalcRepository.findById(item.getId())
 				.orElseThrow(() -> new IllegalStateException("존재하지 않는 상품입니다."));
 
 		return ItemDetailRespDTO.builder()
@@ -31,10 +29,28 @@ public class ItemServiceImpl implements ItemService { // 기본 CRUD API 생성�
 				.itemCode(item.getCode())
 				.price(item.getPrice())
 				.discountRate(item.getDiscountRate())
-				.description(item.getDescription())
-				.status(item.getStatus())
-				.averageStar(itemCalc.getAverageStar())
+				.build();
+	}
+
+	@Override
+	public String getDescription(Long id) {
+		Item item = itemRepository.findById(id)
+				.orElseThrow(() -> new IllegalStateException("존재하지 않는 상품입니다."));
+
+		return item.getDescription();
+	}
+
+	@Override
+	public ItemCalcRespDTO getItemCalc(Long id) {
+		ItemCalc itemCalc = itemCalcRepository.findByItemId(id)
+				.orElseGet(() -> ItemCalc.builder()
+						.averageStar(0.0)
+						.reviewCount(0L)
+						.build());
+
+		return ItemCalcRespDTO.builder()
 				.reviewCount(itemCalc.getReviewCount())
+				.averageStar(itemCalc.getAverageStar())
 				.build();
 	}
 

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
@@ -1,7 +1,5 @@
 package com.comehere.ssgserver.item.application;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 
 import com.comehere.ssgserver.item.domain.Item;
@@ -10,6 +8,7 @@ import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
 import com.comehere.ssgserver.item.infrastructual.ItemCalcRepository;
 import com.comehere.ssgserver.item.infrastructual.ItemRepository;
 import com.comehere.ssgserver.item.vo.ItemListReqVO;
+import com.comehere.ssgserver.item.vo.ItemListRespVO;
 
 import lombok.RequiredArgsConstructor;
 
@@ -40,7 +39,10 @@ public class ItemServiceImpl implements ItemService { // 기본 CRUD API 생성�
 	}
 
 	@Override
-	public List<Long> getItemList(ItemListReqVO vo) {
-		return itemRepository.getItemList(vo);
+	public ItemListRespVO getItemList(ItemListReqVO vo) {
+		return ItemListRespVO.builder()
+				.itemIds(itemRepository.getItemList(vo).stream()
+						.toList())
+				.build();
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
@@ -1,27 +1,26 @@
 package com.comehere.ssgserver.item.application;
 
-import java.util.Optional;
+import java.util.List;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
 
-import com.comehere.ssgserver.clip.domain.ItemClip;
 import com.comehere.ssgserver.item.domain.Item;
 import com.comehere.ssgserver.item.domain.ItemCalc;
 import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
 import com.comehere.ssgserver.item.infrastructual.ItemCalcRepository;
 import com.comehere.ssgserver.item.infrastructual.ItemRepository;
+import com.comehere.ssgserver.item.vo.ItemListReqVO;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class ItemServiceImpl implements ItemService {
+public class ItemServiceImpl implements ItemService { // 기본 CRUD API 생성하기
 	private final ItemRepository itemRepository;
 	private final ItemCalcRepository itemCalcRepository;
 
 	@Override
-	public ItemDetailRespDTO getItemDetail(Long id) {
+	public ItemDetailRespDTO getItemDetail(Long id) { // 상세정보 / 집계 / 기본정보 API 구분
 		Item item = itemRepository.findById(id)
 				.orElseThrow(() -> new IllegalStateException("존재하지 않는 상품입니다."));
 
@@ -38,5 +37,10 @@ public class ItemServiceImpl implements ItemService {
 				.averageStar(itemCalc.getAverageStar())
 				.reviewCount(itemCalc.getReviewCount())
 				.build();
+	}
+
+	@Override
+	public List<Long> getItemList(ItemListReqVO vo) {
+		return itemRepository.getItemList(vo);
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/domain/Item.java
+++ b/src/main/java/com/comehere/ssgserver/item/domain/Item.java
@@ -9,18 +9,20 @@ import lombok.Getter;
 
 @Entity
 @Getter
-public class Item {
+public class Item { // 필드 설정 추가 + @Builder
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(length = 50, nullable = false)
 	private String name;
 
 	private String code;
 
-	@Column(columnDefinition = "LONGTEXT")
+	@Column(columnDefinition = "LONGTEXT", nullable = false)
 	private String description;
 
+	@Column(nullable = false)
 	private Long price;
 
 	private Integer discountRate;

--- a/src/main/java/com/comehere/ssgserver/item/domain/ItemCalc.java
+++ b/src/main/java/com/comehere/ssgserver/item/domain/ItemCalc.java
@@ -1,16 +1,16 @@
 package com.comehere.ssgserver.item.domain;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class ItemCalc {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -18,8 +18,13 @@ public class ItemCalc {
 
 	private Long itemId;
 
-	private Double AverageStar;
+	private Double averageStar;
 
 	private Long reviewCount;
 
+	@Builder
+	public ItemCalc(Double averageStar, Long reviewCount) {
+		this.averageStar = averageStar;
+		this.reviewCount = reviewCount;
+	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/domain/ItemWithCategory.java
+++ b/src/main/java/com/comehere/ssgserver/item/domain/ItemWithCategory.java
@@ -1,9 +1,12 @@
 package com.comehere.ssgserver.item.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 
 @Entity
@@ -12,6 +15,10 @@ public class ItemWithCategory {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "item_id")
+	private Item item;
 
 	private Integer bigCategory;
 

--- a/src/main/java/com/comehere/ssgserver/item/dto/ItemCalcRespDTO.java
+++ b/src/main/java/com/comehere/ssgserver/item/dto/ItemCalcRespDTO.java
@@ -1,0 +1,12 @@
+package com.comehere.ssgserver.item.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ItemCalcRespDTO {
+	private Long reviewCount;
+
+	private Double averageStar;
+}

--- a/src/main/java/com/comehere/ssgserver/item/dto/ItemDetailRespDTO.java
+++ b/src/main/java/com/comehere/ssgserver/item/dto/ItemDetailRespDTO.java
@@ -10,15 +10,7 @@ public class ItemDetailRespDTO {
 
 	private String itemCode;
 
-	private String description;
-
 	private Long price;
 
 	private Integer discountRate;
-
-	private Short status;
-
-	private Long reviewCount;
-
-	private Double averageStar;
 }

--- a/src/main/java/com/comehere/ssgserver/item/infrastructual/CustomItemRepository.java
+++ b/src/main/java/com/comehere/ssgserver/item/infrastructual/CustomItemRepository.java
@@ -1,0 +1,9 @@
+package com.comehere.ssgserver.item.infrastructual;
+
+import java.util.List;
+
+import com.comehere.ssgserver.item.vo.ItemListReqVO;
+
+public interface CustomItemRepository {
+	List<Long> getItemList(ItemListReqVO vo);
+}

--- a/src/main/java/com/comehere/ssgserver/item/infrastructual/CustomItemRepositoryImpl.java
+++ b/src/main/java/com/comehere/ssgserver/item/infrastructual/CustomItemRepositoryImpl.java
@@ -1,11 +1,8 @@
 package com.comehere.ssgserver.item.infrastructual;
 
-import static com.comehere.ssgserver.item.domain.QItem.*;
 import static com.comehere.ssgserver.item.domain.QItemWithCategory.*;
 
 import java.util.List;
-
-import org.springframework.util.StringUtils;
 
 import com.comehere.ssgserver.item.vo.ItemListReqVO;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -22,16 +19,11 @@ public class CustomItemRepositoryImpl implements CustomItemRepository {
 		return query.select(itemWithCategory.item.id)
 				.from(itemWithCategory)
 				.where(
-						itemNameLike(vo.getSearch()),
 						bigCategoryEq(vo.getBigCategoryId()),
 						middleCategoryEq(vo.getMiddleCategoryId()),
 						smallCategoryEq(vo.getSmallCategoryId())
 				)
 				.fetch();
-	}
-
-	private BooleanExpression itemNameLike(String itemName) {
-		return StringUtils.hasText(itemName) ? item.name.like('%' + itemName + '%') : null;
 	}
 
 	private BooleanExpression bigCategoryEq(Integer bigCategoryId) {

--- a/src/main/java/com/comehere/ssgserver/item/infrastructual/CustomItemRepositoryImpl.java
+++ b/src/main/java/com/comehere/ssgserver/item/infrastructual/CustomItemRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.comehere.ssgserver.item.infrastructual;
+
+import static com.comehere.ssgserver.item.domain.QItem.*;
+import static com.comehere.ssgserver.item.domain.QItemWithCategory.*;
+
+import java.util.List;
+
+import org.springframework.util.StringUtils;
+
+import com.comehere.ssgserver.item.vo.ItemListReqVO;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomItemRepositoryImpl implements CustomItemRepository {
+	private final JPAQueryFactory query;
+
+	@Override
+	public List<Long> getItemList(ItemListReqVO vo) {
+		return query.select(itemWithCategory.item.id)
+				.from(itemWithCategory)
+				.where(
+						itemNameLike(vo.getSearch()),
+						bigCategoryEq(vo.getBigCategoryId()),
+						middleCategoryEq(vo.getMiddleCategoryId()),
+						smallCategoryEq(vo.getSmallCategoryId())
+				)
+				.fetch();
+	}
+
+	private BooleanExpression itemNameLike(String itemName) {
+		return StringUtils.hasText(itemName) ? item.name.like('%' + itemName + '%') : null;
+	}
+
+	private BooleanExpression bigCategoryEq(Integer bigCategoryId) {
+		return bigCategoryId != null ? itemWithCategory.bigCategory.eq(bigCategoryId) : null;
+	}
+
+	private BooleanExpression middleCategoryEq(Integer middleCategoryId) {
+		return middleCategoryId != null ? itemWithCategory.middleCategory.eq(middleCategoryId) : null;
+	}
+
+	private BooleanExpression smallCategoryEq(Integer smallCategoryId) {
+		return smallCategoryId != null ? itemWithCategory.smallCategory.eq(smallCategoryId) : null;
+	}
+}

--- a/src/main/java/com/comehere/ssgserver/item/infrastructual/ItemCalcRepository.java
+++ b/src/main/java/com/comehere/ssgserver/item/infrastructual/ItemCalcRepository.java
@@ -3,10 +3,9 @@ package com.comehere.ssgserver.item.infrastructual;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.comehere.ssgserver.item.domain.ItemCalc;
 
 public interface ItemCalcRepository extends JpaRepository<ItemCalc, Long> {
+	Optional<ItemCalc> findByItemId(Long itemId);
 }

--- a/src/main/java/com/comehere/ssgserver/item/infrastructual/ItemRepository.java
+++ b/src/main/java/com/comehere/ssgserver/item/infrastructual/ItemRepository.java
@@ -1,10 +1,8 @@
 package com.comehere.ssgserver.item.infrastructual;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.comehere.ssgserver.item.domain.Item;
-import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
 
-public interface ItemRepository extends JpaRepository<Item, Long> {
+public interface ItemRepository extends JpaRepository<Item, Long>, CustomItemRepository {
 }

--- a/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
+++ b/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
@@ -1,5 +1,7 @@
 package com.comehere.ssgserver.item.presentation;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.comehere.ssgserver.item.application.ItemService;
 import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
+import com.comehere.ssgserver.item.vo.ItemListReqVO;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,5 +26,11 @@ public class ItemController {
 	@Operation(summary = "상품 상세정보 API", description = "상품 상세정보 조회")
 	public ItemDetailRespDTO itemDetail(@PathVariable("id") Long id) {
 		return itemService.getItemDetail(id);
+	}
+
+	@GetMapping
+	@Operation(summary = "상품 목록(ID) 조회 API", description = "조건에 맞는 상품 목록 조회")
+	public List<Long> getItemList(ItemListReqVO vo) {
+		return itemService.getItemList(vo);
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
+++ b/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.comehere.ssgserver.item.application.ItemService;
+import com.comehere.ssgserver.item.dto.ItemCalcRespDTO;
 import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
 import com.comehere.ssgserver.item.vo.ItemListReqVO;
 import com.comehere.ssgserver.item.vo.ItemListRespVO;
@@ -21,10 +22,22 @@ import lombok.RequiredArgsConstructor;
 public class ItemController {
 	private final ItemService itemService;
 
-	@GetMapping("/{id}")
-	@Operation(summary = "상품 상세정보 API", description = "상품 상세정보 조회")
+	@GetMapping("/detail/{id}")
+	@Operation(summary = "상품 기본 정보 API", description = "상품 기본 정보 (상품명, 가격) 조회")
 	public ItemDetailRespDTO itemDetail(@PathVariable("id") Long id) {
 		return itemService.getItemDetail(id);
+	}
+
+	@GetMapping("/description/{id}")
+	@Operation(summary = "상품 상세 정보 API", description = "상품 상세 정보 조회")
+	public String getItemDescription(@PathVariable("id") Long id) {
+		return itemService.getDescription(id);
+	}
+
+	@GetMapping("/calc/{id}")
+	@Operation(summary = "상품 집계 API", description = "상품 집계 정보 (평균 별점, 리뷰 개수) 조회")
+	public ItemCalcRespDTO getItemCalc(@PathVariable("id") Long id) {
+		return itemService.getItemCalc(id);
 	}
 
 	@GetMapping

--- a/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
+++ b/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
@@ -1,7 +1,5 @@
 package com.comehere.ssgserver.item.presentation;
 
-import java.util.List;
-
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.comehere.ssgserver.item.application.ItemService;
 import com.comehere.ssgserver.item.dto.ItemDetailRespDTO;
 import com.comehere.ssgserver.item.vo.ItemListReqVO;
+import com.comehere.ssgserver.item.vo.ItemListRespVO;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,7 +29,7 @@ public class ItemController {
 
 	@GetMapping
 	@Operation(summary = "상품 목록(ID) 조회 API", description = "조건에 맞는 상품 목록 조회")
-	public List<Long> getItemList(ItemListReqVO vo) {
+	public ItemListRespVO getItemList(ItemListReqVO vo) {
 		return itemService.getItemList(vo);
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/vo/ItemListReqVO.java
+++ b/src/main/java/com/comehere/ssgserver/item/vo/ItemListReqVO.java
@@ -6,8 +6,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ItemListReqVO {
-	private String search;
-
 	private Integer bigCategoryId;
 
 	private Integer middleCategoryId;

--- a/src/main/java/com/comehere/ssgserver/item/vo/ItemListReqVO.java
+++ b/src/main/java/com/comehere/ssgserver/item/vo/ItemListReqVO.java
@@ -1,0 +1,17 @@
+package com.comehere.ssgserver.item.vo;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ItemListReqVO {
+	private String search;
+
+	private Integer bigCategoryId;
+
+	private Integer middleCategoryId;
+
+	private Integer smallCategoryId;
+
+}

--- a/src/main/java/com/comehere/ssgserver/item/vo/ItemListRespVO.java
+++ b/src/main/java/com/comehere/ssgserver/item/vo/ItemListRespVO.java
@@ -1,0 +1,12 @@
+package com.comehere.ssgserver.item.vo;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ItemListRespVO {
+	List<Long> itemIds;
+}

--- a/src/main/java/com/comehere/ssgserver/vender/domain/Brand.java
+++ b/src/main/java/com/comehere/ssgserver/vender/domain/Brand.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Entity
 @Getter
-public class Vender {
+public class Brand {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/comehere/ssgserver/vender/domain/BrandWithItem.java
+++ b/src/main/java/com/comehere/ssgserver/vender/domain/BrandWithItem.java
@@ -11,14 +11,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
 @Entity
-public class VenderWithItem {
+public class BrandWithItem {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "vender_id")
-	private Vender vender;
+	@JoinColumn(name = "brand_id")
+	private Brand brand;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "item_id")


### PR DESCRIPTION
## #️⃣연관된 이슈

> #21, #9 

## 📝작업 내용

> 조건에 맞는 상품 목록 

- 모든 상품 조회 : `/items`
- 특정 카테고리의 상품 조회 : `/items?big(/middle/small)CategoryId={id}`
- 특정 검색어를 포함한 상품 조회 : `/items?search={search}`

### 스크린샷 (선택)
1. 상품명에 `a`가 포함된 상품 ID 목록
![image](https://github.com/ComehereTeam/ssg-server/assets/131592978/d8aa715f-fd38-4bdf-a1d5-6686e7ed55a5)

2. 1 + 대 카테고리 id가 2번인 상품 ID 목록
![image](https://github.com/ComehereTeam/ssg-server/assets/131592978/d1f13525-ebc5-416b-827d-f5fdc84fe9f6)

---

> 상품 상세 페이지 API 세분화 : 기본 정보 + 상세 정보 + 브랜드 정보 + 집계 정보

- `/items/detail/{itemId}` : 상품 기본 정보 (상품명, 가격, 할인률 등)
- `/items/description/{itemId}` : 상품 상세 정보
- `/items/brand/{itemId}` : 상품 브랜드 정보
- `/items/calc/{itemId}` : 상품 집계 정보