### PR TITLE
feat : 최근 본 상품 관련 API 개발

### DIFF
--- a/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
@@ -11,6 +11,7 @@ import com.comehere.ssgserver.item.dto.resp.ItemDetailRespDTO;
 import com.comehere.ssgserver.item.dto.resp.ItemImageListRespDTO;
 import com.comehere.ssgserver.item.dto.resp.ItemListRespDTO;
 import com.comehere.ssgserver.item.dto.resp.ItemThumbnailRespDTO;
+import com.comehere.ssgserver.item.dto.resp.RecentViewListRespDTO;
 
 public interface ItemService {
 	ItemDetailRespDTO getItemDetail(Long id);
@@ -28,4 +29,6 @@ public interface ItemService {
 	ItemThumbnailRespDTO getItemThumbnail(Long itemId);
 
 	String createRecentViewItem(Long itemId, UUID uuid);
+
+	RecentViewListRespDTO getRecentViewItems(UUID uuid, Pageable page);
 }

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
@@ -1,5 +1,7 @@
 package com.comehere.ssgserver.item.application;
 
+import java.util.UUID;
+
 import org.springframework.data.domain.Pageable;
 
 import com.comehere.ssgserver.item.dto.req.ItemListReqDTO;
@@ -24,4 +26,6 @@ public interface ItemService {
 	ItemImageListRespDTO getItemImages(Long itemId);
 
 	ItemThumbnailRespDTO getItemThumbnail(Long itemId);
+
+	String createRecentViewItem(Long itemId, UUID uuid);
 }

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemService.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
 
+import com.comehere.ssgserver.item.dto.req.DeleteRecentViewReqDTO;
 import com.comehere.ssgserver.item.dto.req.ItemListReqDTO;
 import com.comehere.ssgserver.item.dto.req.ItemReqDTO;
 import com.comehere.ssgserver.item.dto.resp.ItemCalcRespDTO;
@@ -31,4 +32,6 @@ public interface ItemService {
 	String createRecentViewItem(Long itemId, UUID uuid);
 
 	RecentViewListRespDTO getRecentViewItems(UUID uuid, Pageable page);
+
+	void deleteRecentViewItems(UUID uuid, DeleteRecentViewReqDTO dto);
 }

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
@@ -13,8 +13,8 @@ import com.comehere.ssgserver.common.exception.BaseException;
 import com.comehere.ssgserver.common.response.BaseResponseStatus;
 import com.comehere.ssgserver.item.domain.Item;
 import com.comehere.ssgserver.item.domain.ItemCalc;
-import com.comehere.ssgserver.item.domain.ItemImage;
 import com.comehere.ssgserver.item.domain.RecentViewItem;
+import com.comehere.ssgserver.item.dto.req.DeleteRecentViewReqDTO;
 import com.comehere.ssgserver.item.dto.req.ItemListReqDTO;
 import com.comehere.ssgserver.item.dto.req.ItemReqDTO;
 import com.comehere.ssgserver.item.dto.resp.ImageDTO;
@@ -132,5 +132,11 @@ public class ItemServiceImpl implements ItemService {
 						.toList())
 				.hasNext(items.hasNext())
 				.build();
+	}
+
+	@Override
+	@Transactional
+	public void deleteRecentViewItems(UUID uuid, DeleteRecentViewReqDTO dto) {
+		recentViewItemRepository.deleteByUuidAndIds(uuid, dto.getRecentIds());
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +23,8 @@ import com.comehere.ssgserver.item.dto.resp.ItemDetailRespDTO;
 import com.comehere.ssgserver.item.dto.resp.ItemImageListRespDTO;
 import com.comehere.ssgserver.item.dto.resp.ItemListRespDTO;
 import com.comehere.ssgserver.item.dto.resp.ItemThumbnailRespDTO;
+import com.comehere.ssgserver.item.dto.resp.RecentViewDTO;
+import com.comehere.ssgserver.item.dto.resp.RecentViewListRespDTO;
 import com.comehere.ssgserver.item.infrastructual.ItemCalcRepository;
 import com.comehere.ssgserver.item.infrastructual.ItemImageRepository;
 import com.comehere.ssgserver.item.infrastructual.ItemRepository;
@@ -117,5 +120,17 @@ public class ItemServiceImpl implements ItemService {
 
 			return "UPDATE RECENT VIEW ITEM";
 		}
+	}
+
+	@Override
+	public RecentViewListRespDTO getRecentViewItems(UUID uuid, Pageable page) {
+		Slice<RecentViewItem> items = recentViewItemRepository.findByUuid(uuid, page);
+
+		return RecentViewListRespDTO.builder()
+				.recentItems(items.stream()
+						.map(RecentViewDTO::new)
+						.toList())
+				.hasNext(items.hasNext())
+				.build();
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
@@ -1,5 +1,7 @@
 package com.comehere.ssgserver.item.application;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
@@ -11,6 +13,7 @@ import com.comehere.ssgserver.common.response.BaseResponseStatus;
 import com.comehere.ssgserver.item.domain.Item;
 import com.comehere.ssgserver.item.domain.ItemCalc;
 import com.comehere.ssgserver.item.domain.ItemImage;
+import com.comehere.ssgserver.item.domain.RecentViewItem;
 import com.comehere.ssgserver.item.dto.req.ItemListReqDTO;
 import com.comehere.ssgserver.item.dto.req.ItemReqDTO;
 import com.comehere.ssgserver.item.dto.resp.ImageDTO;
@@ -22,6 +25,7 @@ import com.comehere.ssgserver.item.dto.resp.ItemThumbnailRespDTO;
 import com.comehere.ssgserver.item.infrastructual.ItemCalcRepository;
 import com.comehere.ssgserver.item.infrastructual.ItemImageRepository;
 import com.comehere.ssgserver.item.infrastructual.ItemRepository;
+import com.comehere.ssgserver.item.infrastructual.RecentViewItemRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,6 +36,7 @@ public class ItemServiceImpl implements ItemService {
 	private final ItemRepository itemRepository;
 	private final ItemCalcRepository itemCalcRepository;
 	private final ItemImageRepository itemImageRepository;
+	private final RecentViewItemRepository recentViewItemRepository;
 
 	@Override
 	public ItemDetailRespDTO getItemDetail(Long id) {
@@ -89,5 +94,28 @@ public class ItemServiceImpl implements ItemService {
 	@Override
 	public ItemThumbnailRespDTO getItemThumbnail(Long itemId) {
 		return ItemThumbnailRespDTO.toBuild(itemImageRepository.findThumbnail(itemId));
+	}
+
+	@Override
+	@Transactional
+	public String createRecentViewItem(Long itemId, UUID uuid) {
+		Optional<RecentViewItem> optional = recentViewItemRepository.findByItemIdAndUuid(itemId, uuid);
+
+		if(optional.isEmpty()) {
+			recentViewItemRepository.save(RecentViewItem.builder()
+					.itemId(itemId)
+					.uuid(uuid)
+					.viewDate(LocalDateTime.now())
+					.build());
+
+			return "INSERT RECENT VIEW ITEM";
+		} else {
+			recentViewItemRepository.save(RecentViewItem.builder()
+					.id(optional.get().getId())
+					.viewDate(LocalDateTime.now())
+					.build());
+
+			return "UPDATE RECENT VIEW ITEM";
+		}
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/domain/RecentViewItem.java
+++ b/src/main/java/com/comehere/ssgserver/item/domain/RecentViewItem.java
@@ -1,0 +1,38 @@
+package com.comehere.ssgserver.item.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RecentViewItem {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, updatable = false)
+	private UUID uuid;
+
+	@Column(nullable = false, updatable = false)
+	private Long itemId;
+
+	private LocalDateTime viewDate;
+
+	@Builder
+	public RecentViewItem(Long id, UUID uuid, Long itemId, LocalDateTime viewDate) {
+		this.id = id;
+		this.uuid = uuid;
+		this.itemId = itemId;
+		this.viewDate = viewDate;
+	}
+}

--- a/src/main/java/com/comehere/ssgserver/item/dto/req/DeleteRecentViewReqDTO.java
+++ b/src/main/java/com/comehere/ssgserver/item/dto/req/DeleteRecentViewReqDTO.java
@@ -1,0 +1,10 @@
+package com.comehere.ssgserver.item.dto.req;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class DeleteRecentViewReqDTO {
+	List<Long> recentIds;
+}

--- a/src/main/java/com/comehere/ssgserver/item/dto/resp/RecentViewDTO.java
+++ b/src/main/java/com/comehere/ssgserver/item/dto/resp/RecentViewDTO.java
@@ -1,0 +1,19 @@
+package com.comehere.ssgserver.item.dto.resp;
+
+import java.time.LocalDateTime;
+
+import com.comehere.ssgserver.item.domain.RecentViewItem;
+
+import lombok.Getter;
+
+@Getter
+public class RecentViewDTO {
+	private Long recentId;
+
+	private Long itemId;
+
+	public RecentViewDTO(RecentViewItem items) {
+		this.recentId = items.getId();
+		this.itemId = items.getItemId();
+	}
+}

--- a/src/main/java/com/comehere/ssgserver/item/dto/resp/RecentViewListRespDTO.java
+++ b/src/main/java/com/comehere/ssgserver/item/dto/resp/RecentViewListRespDTO.java
@@ -1,0 +1,15 @@
+package com.comehere.ssgserver.item.dto.resp;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RecentViewListRespDTO {
+	private List<RecentViewDTO> recentItems;
+
+	private Boolean hasNext;
+
+}

--- a/src/main/java/com/comehere/ssgserver/item/infrastructual/RecentViewItemRepository.java
+++ b/src/main/java/com/comehere/ssgserver/item/infrastructual/RecentViewItemRepository.java
@@ -1,11 +1,14 @@
 package com.comehere.ssgserver.item.infrastructual;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.comehere.ssgserver.item.domain.RecentViewItem;
 
@@ -13,4 +16,8 @@ public interface RecentViewItemRepository extends JpaRepository<RecentViewItem, 
 	Optional<RecentViewItem> findByItemIdAndUuid(Long itemId, UUID uuid);
 
 	Slice<RecentViewItem> findByUuid(UUID uuid, Pageable page);
+
+	@Modifying(clearAutomatically = true)
+	@Query("delete from RecentViewItem rvi where rvi.uuid = :uuid and rvi.id in :recentIds")
+	void deleteByUuidAndIds(UUID uuid, List<Long> recentIds);
 }

--- a/src/main/java/com/comehere/ssgserver/item/infrastructual/RecentViewItemRepository.java
+++ b/src/main/java/com/comehere/ssgserver/item/infrastructual/RecentViewItemRepository.java
@@ -3,10 +3,14 @@ package com.comehere.ssgserver.item.infrastructual;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.comehere.ssgserver.item.domain.RecentViewItem;
 
 public interface RecentViewItemRepository extends JpaRepository<RecentViewItem, Long> {
 	Optional<RecentViewItem> findByItemIdAndUuid(Long itemId, UUID uuid);
+
+	Slice<RecentViewItem> findByUuid(UUID uuid, Pageable page);
 }

--- a/src/main/java/com/comehere/ssgserver/item/infrastructual/RecentViewItemRepository.java
+++ b/src/main/java/com/comehere/ssgserver/item/infrastructual/RecentViewItemRepository.java
@@ -1,0 +1,12 @@
+package com.comehere.ssgserver.item.infrastructual;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.comehere.ssgserver.item.domain.RecentViewItem;
+
+public interface RecentViewItemRepository extends JpaRepository<RecentViewItem, Long> {
+	Optional<RecentViewItem> findByItemIdAndUuid(Long itemId, UUID uuid);
+}

--- a/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
+++ b/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,15 +15,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.comehere.ssgserver.common.exception.BaseException;
 import com.comehere.ssgserver.common.response.BaseResponse;
-import com.comehere.ssgserver.common.response.BaseResponseStatus;
 import com.comehere.ssgserver.common.security.jwt.JWTUtil;
-import com.comehere.ssgserver.item.dto.resp.ItemImageListRespDTO;
-import com.comehere.ssgserver.item.dto.resp.ItemThumbnailRespDTO;
 import com.comehere.ssgserver.item.application.ItemService;
+import com.comehere.ssgserver.item.dto.req.DeleteRecentViewReqDTO;
 import com.comehere.ssgserver.item.dto.req.ItemListReqDTO;
 import com.comehere.ssgserver.item.dto.req.ItemReqDTO;
+import com.comehere.ssgserver.item.vo.req.DeleteRecentViewReqVO;
 import com.comehere.ssgserver.item.vo.req.ItemReqVO;
 import com.comehere.ssgserver.item.vo.resp.ItemCalcRespVO;
 import com.comehere.ssgserver.item.vo.resp.ItemDetailRespVO;
@@ -122,5 +121,18 @@ public class ItemController {
 		return new BaseResponse<>(modelMapper.map(
 				itemService.getRecentViewItems(jwtUtil.getUuidByAuthorization(accessToken), page),
 				RecentViewListRespVO.class));
+	}
+
+	@DeleteMapping("/recent")
+	@Operation(summary = "최근 본 상품 내역 삭제 API", description = "최근 본 상품 내역 삭제 (복수 가능)")
+	public BaseResponse<?> deleteRecentViewItem(
+			@RequestHeader(name = "Authorization") String accessToken,
+			@RequestBody DeleteRecentViewReqVO vo) {
+
+		itemService.deleteRecentViewItems(
+				jwtUtil.getUuidByAuthorization(accessToken),
+				modelMapper.map(vo, DeleteRecentViewReqDTO.class));
+
+		return new BaseResponse<>();
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
+++ b/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
@@ -2,6 +2,7 @@ package com.comehere.ssgserver.item.presentation;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,6 +29,7 @@ import com.comehere.ssgserver.item.vo.resp.ItemDetailRespVO;
 import com.comehere.ssgserver.item.vo.resp.ItemImageListRespVO;
 import com.comehere.ssgserver.item.vo.resp.ItemListRespVO;
 import com.comehere.ssgserver.item.vo.resp.ItemThumbnailRespVO;
+import com.comehere.ssgserver.item.vo.resp.RecentViewListRespVO;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -110,5 +112,15 @@ public class ItemController {
 
 		return new BaseResponse<>(itemService
 				.createRecentViewItem(itemId, jwtUtil.getUuidByAuthorization(accessToken)));
+	}
+
+	@GetMapping("/recent")
+	@Operation(summary = "최근 본 상품 내역 조회 API", description = "최근 본 상품 내역 등록 및 수정")
+	public BaseResponse<RecentViewListRespVO> getRecentViewItems(
+			@RequestHeader(name = "Authorization", defaultValue = "") String accessToken,
+			@PageableDefault(size = 10, sort = "viewDate", direction = Sort.Direction.DESC) Pageable page) {
+		return new BaseResponse<>(modelMapper.map(
+				itemService.getRecentViewItems(jwtUtil.getUuidByAuthorization(accessToken), page),
+				RecentViewListRespVO.class));
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/vo/req/DeleteRecentViewReqVO.java
+++ b/src/main/java/com/comehere/ssgserver/item/vo/req/DeleteRecentViewReqVO.java
@@ -1,0 +1,13 @@
+package com.comehere.ssgserver.item.vo.req;
+
+import java.sql.Array;
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+public class DeleteRecentViewReqVO {
+	List<Long> recentIds;
+}

--- a/src/main/java/com/comehere/ssgserver/item/vo/resp/RecentViewListRespVO.java
+++ b/src/main/java/com/comehere/ssgserver/item/vo/resp/RecentViewListRespVO.java
@@ -1,0 +1,12 @@
+package com.comehere.ssgserver.item.vo.resp;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class RecentViewListRespVO {
+	List<RecentViewVO> recentItems;
+
+	private Boolean hasNext;
+}

--- a/src/main/java/com/comehere/ssgserver/item/vo/resp/RecentViewVO.java
+++ b/src/main/java/com/comehere/ssgserver/item/vo/resp/RecentViewVO.java
@@ -1,0 +1,12 @@
+package com.comehere.ssgserver.item.vo.resp;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+
+@Getter
+public class RecentViewVO {
+	private Long recentId;
+
+	private Long itemId;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #113 

## 📝작업 내용

> 최근 본 상품 관련 API 개발 (비회원 X)

- 회원 별 최근 본 상품 목록 조회
- 상세 페이지 접속 시 해당 상품의 방문 일시 저장 API
- 최근 본 상품 내역 삭제 (다중 삭제 가능)

