### PR TITLE
feat: 주문과 주문 리스트 엔티티에 status 필드 추가 및 비회원 주문 생성, 조회 기능 추가

### DIFF
--- a/src/main/java/com/comehere/ssgserver/common/config/SwaggerConfig.java
+++ b/src/main/java/com/comehere/ssgserver/common/config/SwaggerConfig.java
@@ -57,7 +57,8 @@ public class SwaggerConfig {
 	public GroupedOpenApi PurchaseAPI() {
 		return GroupedOpenApi.builder()
 				.group("주문")
-				.pathsToMatch("/api/v1/purchases/**", "/api/v1/clip/**", "/api/v1/review/**", "/api/v1/purchase/**")
+				.pathsToMatch("/api/v1/purchases/**", "/api/v1/clip/**", "/api/v1/review/**", "/api/v1/purchase/**",
+						"/api/v1/non/purchase/**")
 				.build();
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/common/security/SecurityConfig.java
+++ b/src/main/java/com/comehere/ssgserver/common/security/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
 								"/swagger-ui/**", "/swagger-resources/**", "/api-docs/**",
 								"/api/v1/items/**", "/api/v1/categories/**", "/api/v1/bundle/**",
 								"/api/v1/brand/**", "/api/v1/images/**", "/api/v1/review/**",
-								"/api/v1/option/**",
+								"/api/v1/option/**","/api/v1/non/**",
 								"/error")
 						.permitAll()
 						.anyRequest()

--- a/src/main/java/com/comehere/ssgserver/purchase/application/NonPurchaseService.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/application/NonPurchaseService.java
@@ -1,0 +1,12 @@
+package com.comehere.ssgserver.purchase.application;
+
+import com.comehere.ssgserver.purchase.dto.req.NonPurchaseGetReqDTO;
+import com.comehere.ssgserver.purchase.dto.resp.NonPurchaseGetRespDTO;
+
+public interface NonPurchaseService {
+	void createNonPurchase();
+
+	void deleteNonPurchase();
+
+	NonPurchaseGetRespDTO getNonPurchase(NonPurchaseGetReqDTO dto);
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/application/NonPurchaseServiceImp.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/application/NonPurchaseServiceImp.java
@@ -1,0 +1,43 @@
+package com.comehere.ssgserver.purchase.application;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import com.comehere.ssgserver.common.exception.BaseException;
+import com.comehere.ssgserver.common.response.BaseResponseStatus;
+import com.comehere.ssgserver.purchase.dto.req.NonPurchaseGetReqDTO;
+import com.comehere.ssgserver.purchase.dto.resp.NonPurchaseGetRespDTO;
+import com.comehere.ssgserver.purchase.infrastructure.PurchaseListRepository;
+import com.comehere.ssgserver.purchase.infrastructure.PurchaseRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NonPurchaseServiceImp implements NonPurchaseService {
+	private final PurchaseRepository purchaseRepository;
+
+	private final PurchaseListRepository purchaseListRepository;
+
+	private final ModelMapper modelMapper;
+
+	@Override
+	public void createNonPurchase() {
+
+	}
+
+	@Override
+	public void deleteNonPurchase() {
+
+	}
+
+	@Override
+	public NonPurchaseGetRespDTO getNonPurchase(NonPurchaseGetReqDTO dto) {
+		Long findPurchaseId = purchaseRepository.findPurchaseIdByNameAndPhoneAndPurchaseCode(dto)
+				.orElseThrow(() -> new BaseException(BaseResponseStatus.PURCHASE_NOT_FOUND));
+
+		return new NonPurchaseGetRespDTO(purchaseListRepository.findPurchaseListByPurchaseId(findPurchaseId));
+
+	}
+
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/application/PurchaseService.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/application/PurchaseService.java
@@ -16,4 +16,6 @@ public interface PurchaseService {
 	void deletePurchaseList(PurchaseListDeleteReqDTO dto, UUID uuid);
 
 	List<PurchasesGetRespDTO> getPurchases(UUID uuid);
+
+	void deletePurchase(String purchaseCode, UUID uuid);
 }

--- a/src/main/java/com/comehere/ssgserver/purchase/domain/Purchase.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/domain/Purchase.java
@@ -11,6 +11,8 @@ import com.comehere.ssgserver.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -58,12 +60,17 @@ public class Purchase extends BaseEntity {
 	@Column(columnDefinition = "Longtext")
 	private String requestMessage;
 
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private PurchaseStatus status;
+
 	private Boolean deleted;
 
 	@Builder
+
 	public Purchase(Long id, String purchaseCode, UUID uuid, String name, String phone, String email,
 			String addressNickname, String address, String detailAddress, String zipcode, String requestMessage,
-			Boolean deleted) {
+			PurchaseStatus status, Boolean deleted) {
 		this.id = id;
 		this.purchaseCode = purchaseCode;
 		this.uuid = uuid;
@@ -75,6 +82,7 @@ public class Purchase extends BaseEntity {
 		this.detailAddress = detailAddress;
 		this.zipcode = zipcode;
 		this.requestMessage = requestMessage;
+		this.status = status;
 		this.deleted = deleted;
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/purchase/domain/PurchaseList.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/domain/PurchaseList.java
@@ -7,6 +7,8 @@ import com.comehere.ssgserver.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -52,13 +54,16 @@ public class PurchaseList extends BaseEntity {
 	private Boolean wroteReview;
 
 	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private PurchaseListStatus status;
+
+	@Column(nullable = false)
 	private Boolean deleted;
 
 	@Builder
-
 	public PurchaseList(Long id, Long purchaseId, Long itemOptionId, String itemName, Long itemPrice,
 			Integer itemDiscountRate, Integer count, String cancelReason, String detailReason, Boolean wroteReview,
-			Boolean deleted) {
+			PurchaseListStatus status, Boolean deleted) {
 		this.id = id;
 		this.purchaseId = purchaseId;
 		this.itemOptionId = itemOptionId;
@@ -69,6 +74,7 @@ public class PurchaseList extends BaseEntity {
 		this.cancelReason = cancelReason;
 		this.detailReason = detailReason;
 		this.wroteReview = wroteReview;
+		this.status = status;
 		this.deleted = deleted;
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/purchase/domain/PurchaseListStatus.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/domain/PurchaseListStatus.java
@@ -1,0 +1,19 @@
+package com.comehere.ssgserver.purchase.domain;
+
+public enum PurchaseListStatus {
+	WAITING_FOR_PAYMENT("입금 대기중"),
+	ACCEPTED("주문 접수"),
+	CANCEL("주문 취소"),
+	CANCEL_COMPLETED("주문 취소 완료"),
+	PURCHASE_CONFIRMED("입금대"),
+	REFUND_REQUESTED("구매 확정"),
+	REFUND_COMPLETED("환불 요청"),
+	RETURN_REQUESTED("반품 요청"),
+	RETURN_COMPLETED("반품 완료");
+
+	private final String status;
+
+	PurchaseListStatus(String status) {
+		this.status = status;
+	}
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/domain/PurchaseStatus.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/domain/PurchaseStatus.java
@@ -1,0 +1,11 @@
+package com.comehere.ssgserver.purchase.domain;
+
+public enum PurchaseStatus {
+	ACCEPTED("주문 접수"),
+	CANCEL("주문 삭제");
+
+	private final String status;
+	PurchaseStatus(String status) {
+		this.status = status;
+	}
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/dto/req/NonPurchaseGetReqDTO.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/dto/req/NonPurchaseGetReqDTO.java
@@ -1,0 +1,12 @@
+package com.comehere.ssgserver.purchase.dto.req;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NonPurchaseGetReqDTO {
+	private String name;
+	private String phone;
+	private String purchaseCode;
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/dto/resp/NonPurchaseGetRespDTO.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/dto/resp/NonPurchaseGetRespDTO.java
@@ -1,0 +1,12 @@
+package com.comehere.ssgserver.purchase.dto.resp;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NonPurchaseGetRespDTO {
+	private List<Long> purchaseListIds;
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseListRepository.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseListRepository.java
@@ -1,0 +1,11 @@
+package com.comehere.ssgserver.purchase.infrastructure;
+
+import java.util.List;
+
+public interface CustomPurchaseListRepository {
+	boolean existsPurchaseCanceled(Long purchaseId);
+
+	void deleteAllPurchaseList(Long purchaseId);
+
+	List<Long> findPurchaseListByPurchaseId(Long findPurchaseId);
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseListRepositoryImpl.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseListRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.comehere.ssgserver.purchase.infrastructure;
+
+import static com.comehere.ssgserver.purchase.domain.QPurchaseList.*;
+
+import java.util.List;
+
+import com.comehere.ssgserver.purchase.domain.PurchaseListStatus;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomPurchaseListRepositoryImpl implements CustomPurchaseListRepository {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public boolean existsPurchaseCanceled(Long purchaseId) {
+		return queryFactory
+				.selectFrom(purchaseList)
+				.where((purchaseList.status.ne(PurchaseListStatus.CANCEL)).and(purchaseList.purchaseId.eq(purchaseId)))
+				.fetch()
+				.isEmpty();
+	}
+
+	@Override
+	public void deleteAllPurchaseList(Long purchaseId) {
+		queryFactory
+				.update(purchaseList)
+				.set(purchaseList.deleted, true)
+				.where(purchaseList.purchaseId.eq(purchaseId))
+				.execute();
+	}
+
+	@Override
+	public List<Long> findPurchaseListByPurchaseId(Long findPurchaseId) {
+		return queryFactory
+				.select(purchaseList.id)
+				.from(purchaseList)
+				.where(purchaseList.purchaseId.eq(findPurchaseId))
+				.fetch();
+	}
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseRepository.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseRepository.java
@@ -1,0 +1,15 @@
+package com.comehere.ssgserver.purchase.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.comehere.ssgserver.purchase.dto.req.NonPurchaseGetReqDTO;
+
+public interface CustomPurchaseRepository {
+	void updatePurchaseStatusToCancel(Long purchaseId);
+
+	Optional<Long> findPurchaseIdByNameAndPhoneAndPurchaseCode(NonPurchaseGetReqDTO dto);
+
+	List<Long> findPurchaseIdByUuid(UUID uuid);
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseRepositoryImpl.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.comehere.ssgserver.purchase.infrastructure;
+
+import static com.comehere.ssgserver.purchase.domain.QPurchase.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import com.comehere.ssgserver.purchase.domain.PurchaseStatus;
+import com.comehere.ssgserver.purchase.dto.req.NonPurchaseGetReqDTO;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomPurchaseRepositoryImpl implements CustomPurchaseRepository {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public void updatePurchaseStatusToCancel(Long purchaseId) {
+		queryFactory
+				.update(purchase)
+				.set(purchase.status, PurchaseStatus.CANCEL)
+				.execute();
+	}
+
+	@Override
+	public Optional<Long> findPurchaseIdByNameAndPhoneAndPurchaseCode(NonPurchaseGetReqDTO dto) {
+		return Optional.ofNullable(queryFactory
+				.select(purchase.id)
+				.from(purchase)
+				.where(purchase.name.eq(dto.getName())
+						.and(purchase.phone.eq(dto.getPhone()))
+						.and(purchase.purchaseCode.eq(dto.getPurchaseCode())))
+				.fetchOne());
+	}
+
+	@Override
+	public List<Long> findPurchaseIdByUuid(UUID uuid) {
+		return queryFactory
+				.select(purchase.id)
+				.from(purchase)
+				.where(purchase.uuid.eq(uuid))
+				.fetch();
+	}
+
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/infrastructure/PurchaseListRepository.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/infrastructure/PurchaseListRepository.java
@@ -7,12 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.comehere.ssgserver.purchase.domain.PurchaseList;
 
-public interface PurchaseListRepository extends JpaRepository<PurchaseList, Long> {
+public interface PurchaseListRepository extends JpaRepository<PurchaseList, Long>, CustomPurchaseListRepository {
 	boolean existsByPurchaseIdAndItemOptionId(Long purchaseId, Long itemOptionId);
 
 	Optional<PurchaseList> findByIdAndPurchaseId(Long purchaseListId, Long id);
 
-	boolean existsByPurchaseId(Long purchaseId);
-
 	List<PurchaseList> findByPurchaseId(Long id);
+
+	void deleteAllByPurchaseId(Long purchaseId);
 }

--- a/src/main/java/com/comehere/ssgserver/purchase/infrastructure/PurchaseRepository.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/infrastructure/PurchaseRepository.java
@@ -8,9 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.comehere.ssgserver.purchase.domain.Purchase;
 
-public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
+public interface PurchaseRepository extends JpaRepository<Purchase, Long>, CustomPurchaseRepository {
 
 	Optional<Purchase> findByPurchaseCodeAndUuid(String purchaseCode, UUID uuid);
 
-	List<Purchase> findByUuid(UUID uuid);
-}
+	List<Purchase> findByUuid(UUID uuid);}

--- a/src/main/java/com/comehere/ssgserver/purchase/presentation/NonPurchaseController.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/presentation/NonPurchaseController.java
@@ -1,0 +1,58 @@
+package com.comehere.ssgserver.purchase.presentation;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.comehere.ssgserver.common.response.BaseResponse;
+import com.comehere.ssgserver.purchase.application.NonPurchaseService;
+import com.comehere.ssgserver.purchase.application.PurchaseService;
+import com.comehere.ssgserver.purchase.dto.req.NonPurchaseGetReqDTO;
+import com.comehere.ssgserver.purchase.dto.req.PurchaseCreateReqDTO;
+import com.comehere.ssgserver.purchase.dto.resp.NonPurchaseGetRespDTO;
+import com.comehere.ssgserver.purchase.vo.req.NonPurchaseGetReqVO;
+import com.comehere.ssgserver.purchase.vo.req.PurchaseCreateReqVO;
+import com.comehere.ssgserver.purchase.vo.req.PurchaseListDeleteReqVO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/non/purchase")
+@RequiredArgsConstructor
+@Tag(name = "non purchase", description = "비회원 주문 컨트롤러")
+public class NonPurchaseController {
+	private final NonPurchaseService nonPurchaseService;
+
+	private final PurchaseService purchaseService;
+
+	private final ModelMapper modelMapper;
+
+	@PostMapping
+	@Operation(summary = "비회원 주문 등록")
+	public BaseResponse<?> createNonPurchase(@RequestBody PurchaseCreateReqVO vo) {
+		purchaseService.createPurchase(modelMapper.map(vo, PurchaseCreateReqDTO.class), null);
+
+		return new BaseResponse<>();
+	}
+
+	/*@DeleteMapping
+	@Operation(summary = "비회원 주문 리스트 (상품) 취소")
+	public void deleteNonPurchaseList() {
+	}
+
+	@DeleteMapping
+	@Operation(summary = "비회원 주문 삭제")
+	public void deleteNonPurchase() {
+	}*/
+	@GetMapping
+	@Operation(summary = "비회원 주문 조회")
+	public BaseResponse<NonPurchaseGetRespDTO> getNonPurchase(@RequestBody NonPurchaseGetReqVO vo) {
+		return new BaseResponse<>(nonPurchaseService.getNonPurchase(modelMapper.map(vo, NonPurchaseGetReqDTO.class)));
+	}
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/presentation/PurchaseController.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/presentation/PurchaseController.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.modelmapper.ModelMapper;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -41,7 +42,7 @@ public class PurchaseController {
 	@Operation(summary = "주문 등록")
 	public BaseResponse<?> createPurchase(
 			@RequestBody PurchaseCreateReqVO vo,
-			@RequestHeader("Authorization") String authorization) {
+			@RequestHeader(value = "Authorization", required = false) String authorization) {
 
 		UUID uuid = jwtUtil.getUuidByAuthorization(authorization);
 		purchaseService.createPurchase(modelMapper.map(vo, PurchaseCreateReqDTO.class), uuid);
@@ -49,9 +50,9 @@ public class PurchaseController {
 		return new BaseResponse<>();
 	}
 
-	// 주문 삭제
+	// 주문 취소
 	@DeleteMapping
-	@Operation(summary = "주문 삭제")
+	@Operation(summary = "주문 리스트(상품) 취소")
 	public BaseResponse<?> deletePurchaseList(
 			@RequestBody PurchaseListDeleteReqVO vo,
 			@RequestHeader("Authorization") String authorization) {
@@ -62,12 +63,22 @@ public class PurchaseController {
 		return new BaseResponse<>();
 	}
 
+	// 주문 삭제
+	@DeleteMapping("/{purchaseCode}")
+	@Operation(summary = "주문 삭제", description = "주문 삭제시 연관 주문 리스트(상품) 같이 삭제")
+	public BaseResponse<?> deletePurchase(
+			@PathVariable("purchaseCode") String purchaseCode,
+			@RequestHeader("Authorization") String authorization) {
+		UUID uuid = jwtUtil.getUuidByAuthorization(authorization);
+		purchaseService.deletePurchase(purchaseCode, uuid);
+
+		return new BaseResponse<>();
+	}
+
 	// 주문 조회
 	@GetMapping("/list")
 	@Operation(summary = "주문 전체 조회")
-	public BaseResponse<List<PurchasesGetRespVO>>  getPurchases(
-			@RequestHeader("Authorization") String authorization) {
-
+	public BaseResponse<List<PurchasesGetRespVO>> getPurchases(@RequestHeader("Authorization") String authorization) {
 		UUID uuid = jwtUtil.getUuidByAuthorization(authorization);
 
 		return new BaseResponse<>(purchaseService.getPurchases(uuid).stream()

--- a/src/main/java/com/comehere/ssgserver/purchase/vo/req/NonPurchaseGetReqVO.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/vo/req/NonPurchaseGetReqVO.java
@@ -1,0 +1,10 @@
+package com.comehere.ssgserver.purchase.vo.req;
+
+import lombok.Getter;
+
+@Getter
+public class NonPurchaseGetReqVO {
+	private String name;
+	private String phone;
+	private String purchaseCode;
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/vo/resp/NonPurchaseGetRespVO.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/vo/resp/NonPurchaseGetRespVO.java
@@ -1,0 +1,12 @@
+package com.comehere.ssgserver.purchase.vo.resp;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NonPurchaseGetRespVO {
+	private List<Long> purchaseListIds;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #118 

## 📝작업 내용

- 주문 엔티티와 주문 리스트 엔티티에 enum 인 status (주문 상태, 주문 리스트 상태) 필드 추가
- 주문 리스트 취소
- 주문 삭제 
- 비회원 주문 생성
- 비회원 주문 조회 
