### PR TITLE
refactor : 목록 조회 API - 페이징 적용

### DIFF
--- a/src/main/java/com/comehere/ssgserver/bundle/presentation/BundleController.java
+++ b/src/main/java/com/comehere/ssgserver/bundle/presentation/BundleController.java
@@ -43,7 +43,7 @@ public class BundleController {
 	@Operation(summary = "묶음(특가) 상품 ID 조회 API", description = "묶음(특가) 상품 목록 조회")
 	public BaseResponse<BundleListRespVO> getBundleList(
 			@RequestParam(required = false) Integer categoryId,
-			@PageableDefault(size = 20) Pageable page) {
+			@PageableDefault(size = 5) Pageable page) {
 		log.info("묶음 상품 목록 조회 : categoryId={}", categoryId);
 		return new BaseResponse<>(modelMapper.map(
 				bundleService.getBundleList(categoryId, page), BundleListRespVO.class));

--- a/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
+++ b/src/main/java/com/comehere/ssgserver/item/application/ItemServiceImpl.java
@@ -130,6 +130,7 @@ public class ItemServiceImpl implements ItemService {
 				.recentItems(items.stream()
 						.map(RecentViewDTO::new)
 						.toList())
+				.currentPage(items.getNumber())
 				.hasNext(items.hasNext())
 				.build();
 	}

--- a/src/main/java/com/comehere/ssgserver/item/dto/resp/ItemListRespDTO.java
+++ b/src/main/java/com/comehere/ssgserver/item/dto/resp/ItemListRespDTO.java
@@ -11,13 +11,16 @@ import lombok.Setter;
 @Getter
 @Builder
 public class ItemListRespDTO {
-	List<Long> itemIds;
+	private List<Long> itemIds;
 
-	Boolean hasNext;
+	private Integer currentPage;
+
+	private  Boolean hasNext;
 
 	public static ItemListRespDTO toBuild(Slice<Long> slice) {
 		return ItemListRespDTO.builder()
 				.itemIds(slice.getContent())
+				.currentPage(slice.getNumber())
 				.hasNext(slice.hasNext())
 				.build();
 	}

--- a/src/main/java/com/comehere/ssgserver/item/dto/resp/RecentViewListRespDTO.java
+++ b/src/main/java/com/comehere/ssgserver/item/dto/resp/RecentViewListRespDTO.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 public class RecentViewListRespDTO {
 	private List<RecentViewDTO> recentItems;
 
+	private Integer currentPage;
+
 	private Boolean hasNext;
 
 }

--- a/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
+++ b/src/main/java/com/comehere/ssgserver/item/presentation/ItemController.java
@@ -75,7 +75,7 @@ public class ItemController {
 			@RequestParam(required = false) Integer detailCategoryId,
 			@RequestParam(required = false) Long brandId,
 			@RequestParam(required = false) String search,
-			@PageableDefault(size = 40) Pageable page) {
+			@PageableDefault(size = 20) Pageable page) {
 
 		log.info("카테고리 별 상품 목록 조회 : big={}, middle={}, small={}, detail={}, brandId={}, search={}",
 				bigCategoryId, middleCategoryId, smallCategoryId, detailCategoryId, brandId, search);

--- a/src/main/java/com/comehere/ssgserver/item/vo/resp/ItemListRespVO.java
+++ b/src/main/java/com/comehere/ssgserver/item/vo/resp/ItemListRespVO.java
@@ -12,7 +12,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ItemListRespVO {
-	List<Long> itemIds;
+	private List<Long> itemIds;
 
-	Boolean hasNext;
+	private Integer currentPage;
+
+	private Boolean hasNext;
 }

--- a/src/main/java/com/comehere/ssgserver/item/vo/resp/RecentViewListRespVO.java
+++ b/src/main/java/com/comehere/ssgserver/item/vo/resp/RecentViewListRespVO.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 
 @Getter
 public class RecentViewListRespVO {
-	List<RecentViewVO> recentItems;
+	private List<RecentViewVO> recentItems;
+
+	private Integer currentPage;
 
 	private Boolean hasNext;
 }

--- a/src/main/java/com/comehere/ssgserver/review/application/ReviewImageServiceImp.java
+++ b/src/main/java/com/comehere/ssgserver/review/application/ReviewImageServiceImp.java
@@ -112,6 +112,7 @@ public class ReviewImageServiceImp implements ReviewImageService {
 		return ReviewImageListRespDTO.builder()
 				.itemCode(itemCode)
 				.images(reviews.getContent())
+				.currentPage(reviews.getNumber())
 				.hasNext(reviews.hasNext())
 				.build();
 	}

--- a/src/main/java/com/comehere/ssgserver/review/dto/resp/ReviewImageListRespDTO.java
+++ b/src/main/java/com/comehere/ssgserver/review/dto/resp/ReviewImageListRespDTO.java
@@ -12,5 +12,7 @@ public class ReviewImageListRespDTO {
 
 	private List<ReviewImageListDTO> images;
 
+	private Integer currentPage;
+
 	private Boolean hasNext;
 }

--- a/src/main/java/com/comehere/ssgserver/review/dto/resp/ReviewListRespDTO.java
+++ b/src/main/java/com/comehere/ssgserver/review/dto/resp/ReviewListRespDTO.java
@@ -10,14 +10,16 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ReviewListRespDTO {
-
 	private List<Long> reviews;
+
+	private Integer currentPage;
 
 	private Boolean hasNext;
 
 	public static ReviewListRespDTO toBuild(Slice<Long> reviews) {
 		return ReviewListRespDTO.builder()
 				.reviews(reviews.getContent())
+				.currentPage(reviews.getNumber())
 				.hasNext(reviews.hasNext())
 				.build();
 	}

--- a/src/main/java/com/comehere/ssgserver/review/presentation/ReviewController.java
+++ b/src/main/java/com/comehere/ssgserver/review/presentation/ReviewController.java
@@ -169,7 +169,7 @@ public class ReviewController {
 	@Operation(summary = "상품 별 전체 리뷰 이미지 조회")
 	public BaseResponse<ReviewImageListRespVO> getReviewImageList(
 			@PathVariable("itemCode") String itemCode,
-			@PageableDefault(size = 5) Pageable page) {
+			@PageableDefault(size = 20) Pageable page) {
 		log.info("상품 리뷰 이미지 전체 조회 : itemCode={}", itemCode);
 		return new BaseResponse<>(modelMapper.map(
 				reviewImageService.getReviewImageList(itemCode, page),

--- a/src/main/java/com/comehere/ssgserver/review/vo/resp/ReviewImageListRespVO.java
+++ b/src/main/java/com/comehere/ssgserver/review/vo/resp/ReviewImageListRespVO.java
@@ -12,5 +12,7 @@ public class ReviewImageListRespVO {
 
 	private List<ReviewImageListDTO> images;
 
+	private Integer currentPage;
+
 	private Boolean hasNext;
 }

--- a/src/main/java/com/comehere/ssgserver/review/vo/resp/ReviewListRespVO.java
+++ b/src/main/java/com/comehere/ssgserver/review/vo/resp/ReviewListRespVO.java
@@ -6,8 +6,9 @@ import lombok.Getter;
 
 @Getter
 public class ReviewListRespVO {
-
 	private List<Long> reviews;
+
+	private Integer currentPage;
 
 	private Boolean hasNext;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #152 

## 📝작업 내용

> 목록 조회 API : 페이징 반환 형태 통일 -> `result` + `currentPage` (현재 페이지) + `hasNext` (다음 페이지 존재 여부)
![image](https://github.com/ComehereTeam/ssg-server/assets/131592978/e47a3f70-47d3-43d2-8b0c-7788279282db)
