### PR TITLE
fix: 상품 검색 로직 수정

### DIFF
--- a/src/main/java/com/comehere/ssgserver/item/dto/req/ItemListReqDTO.java
+++ b/src/main/java/com/comehere/ssgserver/item/dto/req/ItemListReqDTO.java
@@ -1,5 +1,7 @@
 package com.comehere.ssgserver.item.dto.req;
 
+import java.util.List;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,7 +18,7 @@ public class ItemListReqDTO {
 
 	private Long brandId;
 
-	private String search;
+	private String[] search;
 
 	public static ItemListReqDTO toBuild(
 			Integer bigCategoryId,
@@ -32,7 +34,7 @@ public class ItemListReqDTO {
 				.smallCategoryId(smallCategoryId)
 				.detailCategoryId(detailCategoryId)
 				.brandId(brandId)
-				.search(search)
+				.search(search != null ? search.split(" ") : null)
 				.build();
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/item/infrastructual/CustomItemRepositoryImpl.java
+++ b/src/main/java/com/comehere/ssgserver/item/infrastructual/CustomItemRepositoryImpl.java
@@ -1,9 +1,9 @@
 package com.comehere.ssgserver.item.infrastructual;
 
 import static com.comehere.ssgserver.brand.domain.QBrandWithItem.*;
-import static com.comehere.ssgserver.item.domain.QItem.*;
 import static com.comehere.ssgserver.item.domain.QItemWithCategory.*;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
@@ -12,7 +12,6 @@ import org.springframework.data.domain.SliceImpl;
 
 import com.comehere.ssgserver.item.dto.req.ItemListReqDTO;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -68,11 +67,16 @@ public class CustomItemRepositoryImpl implements CustomItemRepository {
 		return brandId != null ? brandWithItem.brand.id.eq(brandId) : null;
 	}
 
-	private BooleanExpression itemNameLike(String itemName) {
-		return itemName != null ?
-				Expressions.stringTemplate(
-						"function('replace', {0}, ' ', '')", itemWithCategory.item.name.toLowerCase())
-						.like("%" + itemName + "%")
-				: null;
+	private BooleanExpression itemNameLike(String[] itemName) {
+		if(itemName == null || itemName.length == 0) {
+			return null;
+		}
+
+		System.out.println(Arrays.toString(itemName));
+
+		return Arrays.stream(itemName)
+				.map(itemWithCategory.item.name::contains)
+				.reduce(BooleanExpression::and)
+				.orElse(null);
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #140 

## 📝작업 내용

> 검색 로직 수정

- 기존 로직 : 키워드를 정확히 포함하는 상품만 반환 -> ex) '구찌 스카프' 검색 시 `name like '%구찌 스카프%'`가 실행되어 '구찌 GG 플라워 실크 스카프'를 반환하지 않음

- 수정 로직 : 띄어쓰기를 기준으로 모든 키워드를 포함하는 상품 반환 -> '구찌 스카프' 검색 시 `name like '%구찌%' and name like '%스카프%'`가 실행되어 각 키워드를 모두 포함하는 '구찌 GG 플라워 실크 스카프' 반환

### 스크린샷 (선택)

![image](https://github.com/4-ComehereTeam/ssg-server/assets/131592978/8f09c9d6-505a-4da0-8b4e-a7dc1e433b4f)

![image](https://github.com/4-ComehereTeam/ssg-server/assets/131592978/c0e48fff-ef39-472d-9cf0-6aecca0d99fc)
