### PR TITLE
feat: 상품 조회 페이징, 날짜별, 주문 상태에 따른 조회 기능 구현

### DIFF
--- a/src/main/java/com/comehere/ssgserver/purchase/application/PurchaseService.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/application/PurchaseService.java
@@ -3,7 +3,10 @@ package com.comehere.ssgserver.purchase.application;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
+
 import com.comehere.ssgserver.purchase.dto.req.PurchaseCreateReqDTO;
+import com.comehere.ssgserver.purchase.dto.req.PurchaseGetReqDTO;
 import com.comehere.ssgserver.purchase.dto.req.PurchaseListCreateReqDTO;
 import com.comehere.ssgserver.purchase.dto.req.PurchaseListDeleteReqDTO;
 import com.comehere.ssgserver.purchase.dto.resp.PurchaseCreateRespDTO;
@@ -17,7 +20,7 @@ public interface PurchaseService {
 
 	void deletePurchaseList(PurchaseListDeleteReqDTO dto, UUID uuid);
 
-	List<PurchasesGetRespDTO> getPurchases(UUID uuid);
+	List<PurchasesGetRespDTO> getPurchases(UUID uuid, PurchaseGetReqDTO dto, Pageable page);
 
 	void deletePurchase(String purchaseCode, UUID uuid);
 

--- a/src/main/java/com/comehere/ssgserver/purchase/application/PurchaseServiceImp.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/application/PurchaseServiceImp.java
@@ -7,19 +7,20 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.comehere.ssgserver.common.exception.BaseException;
 import com.comehere.ssgserver.common.response.BaseResponseStatus;
 import com.comehere.ssgserver.item.domain.Item;
-import com.comehere.ssgserver.member.infrastructure.MemberRepository;
 import com.comehere.ssgserver.option.infrastructure.ItemOptionRepository;
 import com.comehere.ssgserver.purchase.domain.Purchase;
 import com.comehere.ssgserver.purchase.domain.PurchaseList;
 import com.comehere.ssgserver.purchase.domain.PurchaseListStatus;
 import com.comehere.ssgserver.purchase.domain.PurchaseStatus;
 import com.comehere.ssgserver.purchase.dto.req.PurchaseCreateReqDTO;
+import com.comehere.ssgserver.purchase.dto.req.PurchaseGetReqDTO;
 import com.comehere.ssgserver.purchase.dto.req.PurchaseListCreateReqDTO;
 import com.comehere.ssgserver.purchase.dto.req.PurchaseListDeleteReqDTO;
 import com.comehere.ssgserver.purchase.dto.resp.PurchaseCreateRespDTO;
@@ -134,14 +135,14 @@ public class PurchaseServiceImp implements PurchaseService {
 	}
 
 	@Override
-	public List<PurchasesGetRespDTO> getPurchases(UUID uuid) {
-		return purchaseRepository.findByUuid(uuid)
+	public List<PurchasesGetRespDTO> getPurchases(UUID uuid, PurchaseGetReqDTO dto, Pageable page) {
+		return purchaseRepository.findPurchaseByUuidAndDate(uuid, dto, page)
 				.stream()
-				.map(purchase -> PurchasesGetRespDTO.builder()
-						.purchaseCode(purchase.getPurchaseCode())
-						.purchaseListIds(getPurchaseListIds(purchase))
+				.map(respDTO -> PurchasesGetRespDTO.builder()
+						.purchaseCode(respDTO.getPurchaseCode())
+						.purchaseListIds(getPurchaseListIds(respDTO.getId()))
 						.build())
-				.collect(Collectors.toList());
+				.toList();
 	}
 
 	@Override
@@ -183,11 +184,9 @@ public class PurchaseServiceImp implements PurchaseService {
 		}
 	}
 
-	private List<Long> getPurchaseListIds(Purchase purchase) {
-		return purchaseListRepository.findByPurchaseId(purchase.getId())
-				.stream()
-				.map(PurchaseList::getId)
-				.collect(Collectors.toList());
+	private List<Long> getPurchaseListIds(Long purchaseId) {
+		return purchaseListRepository.findIdsByPurchaseId(purchaseId);
+
 	}
 
 	private String makePurchaseCode() {

--- a/src/main/java/com/comehere/ssgserver/purchase/dto/req/PurchaseGetReqDTO.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/dto/req/PurchaseGetReqDTO.java
@@ -1,0 +1,18 @@
+package com.comehere.ssgserver.purchase.dto.req;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PurchaseGetReqDTO {
+	private String startDate;
+	private String endDate;
+	private Boolean acceptedStatus;
+
+	@Builder
+	public PurchaseGetReqDTO(String startDate, String endDate, Boolean acceptedStatus) {
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.acceptedStatus = acceptedStatus;
+	}
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/dto/resp/PurchaseGetRespDTO.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/dto/resp/PurchaseGetRespDTO.java
@@ -1,0 +1,19 @@
+package com.comehere.ssgserver.purchase.dto.resp;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PurchaseGetRespDTO {
+	private Long id;
+
+	private String purchaseCode;
+
+	@Builder
+	public PurchaseGetRespDTO(Long id, String purchaseCode) {
+		this.id = id;
+		this.purchaseCode = purchaseCode;
+	}
+}

--- a/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseListRepository.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseListRepository.java
@@ -14,4 +14,6 @@ public interface CustomPurchaseListRepository {
 	List<Long> findPurchaseListByPurchaseId(Long findPurchaseId);
 
 	Optional<PurchaseListByIdAndUuidRespDTO> getRespDTOByIdAndUuid(Long purchaseListId, UUID uuid);
+
+	List<Long> findIdsByPurchaseId(Long purchaseId);
 }

--- a/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseListRepositoryImpl.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseListRepositoryImpl.java
@@ -59,4 +59,12 @@ public class CustomPurchaseListRepositoryImpl implements CustomPurchaseListRepos
 				.where(purchaseList.id.eq(purchaseListId).and(purchase.uuid.eq(uuid)))
 				.fetchOne());
 	}
+
+	@Override
+	public List<Long> findIdsByPurchaseId(Long purchaseId) {
+		return queryFactory.select(purchaseList.id)
+				.from(purchaseList)
+				.where(purchaseList.purchaseId.eq(purchaseId))
+				.fetch();
+	}
 }

--- a/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseRepository.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseRepository.java
@@ -4,12 +4,16 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
+
 import com.comehere.ssgserver.purchase.dto.req.NonPurchaseGetReqDTO;
+import com.comehere.ssgserver.purchase.dto.req.PurchaseGetReqDTO;
+import com.comehere.ssgserver.purchase.dto.resp.PurchaseGetRespDTO;
 
 public interface CustomPurchaseRepository {
 	void updatePurchaseStatusToCancel(Long purchaseId);
 
 	Optional<Long> findIdPurchaseIdBySenderNameAndSenderPhoneAndPurchaseCode(NonPurchaseGetReqDTO dto);
 
-	List<Long> findPurchaseIdByUuid(UUID uuid);
+	List<PurchaseGetRespDTO> findPurchaseByUuidAndDate(UUID uuid, PurchaseGetReqDTO dto, Pageable page);
 }

--- a/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseRepositoryImpl.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseRepositoryImpl.java
@@ -2,12 +2,20 @@ package com.comehere.ssgserver.purchase.infrastructure;
 
 import static com.comehere.ssgserver.purchase.domain.QPurchase.*;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
+
 import com.comehere.ssgserver.purchase.domain.PurchaseStatus;
 import com.comehere.ssgserver.purchase.dto.req.NonPurchaseGetReqDTO;
+import com.comehere.ssgserver.purchase.dto.req.PurchaseGetReqDTO;
+import com.comehere.ssgserver.purchase.dto.resp.PurchaseGetRespDTO;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -36,12 +44,30 @@ public class CustomPurchaseRepositoryImpl implements CustomPurchaseRepository {
 	}
 
 	@Override
-	public List<Long> findPurchaseIdByUuid(UUID uuid) {
-		return queryFactory
-				.select(purchase.id)
+	public List<PurchaseGetRespDTO> findPurchaseByUuidAndDate(UUID uuid, PurchaseGetReqDTO dto, Pageable page) {
+		return queryFactory.select(Projections.fields(PurchaseGetRespDTO.class,
+						purchase.id,
+						purchase.purchaseCode
+				))
 				.from(purchase)
-				.where(purchase.uuid.eq(uuid))
+				.where(creatAtAfter(dto.getStartDate()),
+						createAtBefore(dto.getEndDate()),
+						checkAcceptedPurchaseStatus(dto.getAcceptedStatus()))
+				.offset(page.getOffset())
+				.limit(page.getPageSize())
+				.orderBy(purchase.createAt.desc())
 				.fetch();
 	}
 
+	private BooleanExpression creatAtAfter(String startDate) {
+		return startDate == null ? null : purchase.createAt.after(LocalDate.parse(startDate).atStartOfDay());
+	}
+
+	private BooleanExpression createAtBefore(String endDate) {
+		return endDate == null ? null : purchase.createAt.before(LocalDate.parse(endDate).atTime(LocalTime.MAX));
+	}
+
+	private BooleanExpression checkAcceptedPurchaseStatus(Boolean acceptedStatus) {
+		return Boolean.TRUE.equals(acceptedStatus) ? purchase.status.eq(PurchaseStatus.ACCEPTED) : null;
+	}
 }

--- a/src/main/java/com/comehere/ssgserver/purchase/infrastructure/PurchaseListRepository.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/infrastructure/PurchaseListRepository.java
@@ -1,6 +1,5 @@
 package com.comehere.ssgserver.purchase.infrastructure;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +10,4 @@ public interface PurchaseListRepository extends JpaRepository<PurchaseList, Long
 	boolean existsByPurchaseIdAndItemOptionId(Long purchaseId, Long itemOptionId);
 
 	Optional<PurchaseList> findByIdAndPurchaseId(Long purchaseListId, Long id);
-
-	List<PurchaseList> findByPurchaseId(Long id);
 }

--- a/src/main/java/com/comehere/ssgserver/purchase/presentation/PurchaseController.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/presentation/PurchaseController.java
@@ -2,9 +2,10 @@ package com.comehere.ssgserver.purchase.presentation;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,12 +13,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.comehere.ssgserver.common.response.BaseResponse;
 import com.comehere.ssgserver.common.security.jwt.JWTUtil;
 import com.comehere.ssgserver.purchase.application.PurchaseService;
 import com.comehere.ssgserver.purchase.dto.req.PurchaseCreateReqDTO;
+import com.comehere.ssgserver.purchase.dto.req.PurchaseGetReqDTO;
 import com.comehere.ssgserver.purchase.dto.req.PurchaseListDeleteReqDTO;
 import com.comehere.ssgserver.purchase.dto.resp.PurchaseCreateRespDTO;
 import com.comehere.ssgserver.purchase.vo.req.PurchaseCreateReqVO;
@@ -79,12 +82,24 @@ public class PurchaseController {
 
 	@GetMapping
 	@Operation(summary = "주문 전체 조회")
-	public BaseResponse<List<PurchasesGetRespVO>> getPurchases(@RequestHeader("Authorization") String authorization) {
+	public BaseResponse<List<PurchasesGetRespVO>> getPurchases(
+			@RequestHeader("Authorization") String authorization,
+			@RequestParam(value = "startDate", required = false) String startDate,
+			@RequestParam(value = "endDate", required = false) String endDate,
+			@RequestParam(value = "acceptedStatus", required = false) Boolean acceptedStatus,
+			@PageableDefault(size = 5) Pageable page) {
 		UUID uuid = jwtUtil.getUuidByAuthorization(authorization);
 
-		return new BaseResponse<>(purchaseService.getPurchases(uuid).stream()
-				.map(dto -> modelMapper.map(dto, PurchasesGetRespVO.class))
-				.collect(Collectors.toList()));
+		PurchaseGetReqDTO reqDTO = PurchaseGetReqDTO.builder()
+				.startDate(startDate)
+				.endDate(endDate)
+				.acceptedStatus(acceptedStatus)
+				.build();
+
+		return new BaseResponse<>(
+				purchaseService.getPurchases(uuid, reqDTO, page).stream()
+						.map(respDTO -> modelMapper.map(respDTO, PurchasesGetRespVO.class))
+						.toList());
 	}
 
 	@GetMapping("/{purchaseListId}")


### PR DESCRIPTION
## #️⃣연관된 이슈

> #156 

API 예시 
> GET : /api/v1/purchase?startDate=2024-01-09&endDate=2024-03-09&acceptedStatus=true&page=2

- 페이징 기능 구현
- 날짜별 조회
- 주문 상태가 접수인 상품만 조회  

<img width="268" alt="image" src="https://github.com/4-ComehereTeam/ssg-server/assets/124120054/a7755d7f-51e1-45aa-98a2-0829d29d2fe0">
