### PR TITLE
refactor: 주문 전체 조회 성능을 위한 리팩토링 v2 생성

### DIFF
--- a/src/main/java/com/comehere/ssgserver/purchase/application/PurchaseServiceImp.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/application/PurchaseServiceImp.java
@@ -143,6 +143,9 @@ public class PurchaseServiceImp implements PurchaseService {
 						.purchaseListIds(getPurchaseListIds(respDTO.getId()))
 						.build())
 				.toList();
+
+	 // return purchaseRepository.findPurchaseByUuidAndDate_v2(uuid, dto, page);
+
 	}
 
 	@Override

--- a/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseRepository.java
+++ b/src/main/java/com/comehere/ssgserver/purchase/infrastructure/CustomPurchaseRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import com.comehere.ssgserver.purchase.dto.req.NonPurchaseGetReqDTO;
 import com.comehere.ssgserver.purchase.dto.req.PurchaseGetReqDTO;
 import com.comehere.ssgserver.purchase.dto.resp.PurchaseGetRespDTO;
+import com.comehere.ssgserver.purchase.dto.resp.PurchasesGetRespDTO;
 
 public interface CustomPurchaseRepository {
 	void updatePurchaseStatusToCancel(Long purchaseId);
@@ -16,4 +17,6 @@ public interface CustomPurchaseRepository {
 	Optional<Long> findIdPurchaseIdBySenderNameAndSenderPhoneAndPurchaseCode(NonPurchaseGetReqDTO dto);
 
 	List<PurchaseGetRespDTO> findPurchaseByUuidAndDate(UUID uuid, PurchaseGetReqDTO dto, Pageable page);
+
+	List<PurchasesGetRespDTO> findPurchaseByUuidAndDate_v2(UUID uuid, PurchaseGetReqDTO dto, Pageable page);
 }


### PR DESCRIPTION
## 📝작업 내용

> 주문 조회 시 주문 코드에 대한 주문리스트를 가져오는 기능
- 모든 주문을 조회 시 10건을 조회하게 되면 11건의 쿼리가 발생 -> 성능 저하 
- 조인을 통한 1건의 쿼리로 모든 주문을 조회하는 findPurchaseByUuidAndDate_v2 메서드 생성