### PR TITLE
feat: 카테고리 좋아요 삭제 안될 시 예외 처리 구현 및 카테고리 좋아요 조회 응답값 id 추가

### DIFF
--- a/src/main/java/com/comehere/ssgserver/clip/application/CategoryClipService.java
+++ b/src/main/java/com/comehere/ssgserver/clip/application/CategoryClipService.java
@@ -2,10 +2,12 @@ package com.comehere.ssgserver.clip.application;
 
 import java.util.UUID;
 
-import com.comehere.ssgserver.clip.dto.req.CateGoryClipStatusGetReqDTO;
+import com.comehere.ssgserver.clip.dto.req.CateGoryClipGetReqDTO;
 import com.comehere.ssgserver.clip.dto.req.CategoriesClipDeleteReqDTO;
 import com.comehere.ssgserver.clip.dto.req.CategoryClipCreateReqDTO;
 import com.comehere.ssgserver.clip.dto.resp.CategoriesClipGetRespDTO;
+import com.comehere.ssgserver.clip.dto.resp.CategoryClipGetInfoRespDTO;
+import com.comehere.ssgserver.clip.dto.resp.CategoryClipGetRespDTO;
 
 public interface CategoryClipService {
 	void createCategoryClip(UUID uuid, CategoryClipCreateReqDTO dto);
@@ -14,5 +16,7 @@ public interface CategoryClipService {
 
 	CategoriesClipGetRespDTO getCategoriesClip(UUID uuid);
 
-	Boolean getCategoryClipStatus(UUID uuid, CateGoryClipStatusGetReqDTO dto);
+	Boolean getCategoryClipStatus(UUID uuid, CateGoryClipGetReqDTO dto);
+
+	CategoryClipGetInfoRespDTO getCategoryClip(UUID uuid, CateGoryClipGetReqDTO dto);
 }

--- a/src/main/java/com/comehere/ssgserver/clip/application/CategoryClipServiceImp.java
+++ b/src/main/java/com/comehere/ssgserver/clip/application/CategoryClipServiceImp.java
@@ -1,15 +1,19 @@
 package com.comehere.ssgserver.clip.application;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.comehere.ssgserver.clip.domain.CategoryClip;
-import com.comehere.ssgserver.clip.dto.req.CateGoryClipStatusGetReqDTO;
+import com.comehere.ssgserver.clip.dto.req.CateGoryClipGetReqDTO;
 import com.comehere.ssgserver.clip.dto.req.CategoriesClipDeleteReqDTO;
 import com.comehere.ssgserver.clip.dto.req.CategoryClipCreateReqDTO;
 import com.comehere.ssgserver.clip.dto.resp.CategoriesClipGetRespDTO;
+import com.comehere.ssgserver.clip.dto.resp.CategoryClipGetInfoRespDTO;
+import com.comehere.ssgserver.clip.dto.resp.CategoryClipGetRespDTO;
 import com.comehere.ssgserver.clip.infrastructure.CategoryClipRepository;
 import com.comehere.ssgserver.common.exception.BaseException;
 import com.comehere.ssgserver.common.response.BaseResponseStatus;
@@ -39,11 +43,17 @@ public class CategoryClipServiceImp implements CategoryClipService {
 	@Override
 	@Transactional
 	public void deleteCategoriesClip(UUID uuid, CategoriesClipDeleteReqDTO dto) {
+		List<Boolean> deleteResult = new ArrayList<>();
+
 		dto.getCategoryClipIds()
 				.forEach(categoryClipDeleteReqDTO -> {
-					categoryClipRepository.deleteByUuidAndBigCategoryIdAndMiddleCategoryIdAndSmallCategoryId(uuid,
-							categoryClipDeleteReqDTO);
+					deleteResult.add(categoryClipRepository.deleteByUuidAndBigCategoryIdAndMiddleCategoryIdAndSmallCategoryId(uuid,
+							categoryClipDeleteReqDTO));
 				});
+
+		if (deleteResult.contains(false)) {
+			throw new BaseException(BaseResponseStatus.CLIP_CATEGORY_NOT_DELETED);
+		}
 	}
 
 	@Override
@@ -54,7 +64,7 @@ public class CategoryClipServiceImp implements CategoryClipService {
 	}
 
 	@Override
-	public Boolean getCategoryClipStatus(UUID uuid, CateGoryClipStatusGetReqDTO dto) {
+	public Boolean getCategoryClipStatus(UUID uuid, CateGoryClipGetReqDTO dto) {
 		if (categoryClipRepository.existsByUuidAndBigCategoryIdAndMiddleCategoryIdAndSmallCategoryId(uuid,
 				dto.getBigCategoryId(),
 				dto.getMiddleCategoryId(),
@@ -63,5 +73,16 @@ public class CategoryClipServiceImp implements CategoryClipService {
 		}
 
 		throw new BaseException(BaseResponseStatus.CLIP_CATEGORY_NOT_FOUND);
+	}
+
+	@Override
+	public CategoryClipGetInfoRespDTO getCategoryClip(UUID uuid, CateGoryClipGetReqDTO dto) {
+		Long categoryClipId = categoryClipRepository.findIdByUuidAndBigCategoryIdAndMiddleCategoryIdAndSmallCategoryId(
+				uuid, dto).orElseThrow(() -> new BaseException(BaseResponseStatus.CLIP_CATEGORY_NOT_FOUND));
+
+		return CategoryClipGetInfoRespDTO.builder()
+				.id(categoryClipId)
+				.isCliped(true)
+				.build();
 	}
 }

--- a/src/main/java/com/comehere/ssgserver/clip/dto/req/CateGoryClipGetReqDTO.java
+++ b/src/main/java/com/comehere/ssgserver/clip/dto/req/CateGoryClipGetReqDTO.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class CateGoryClipStatusGetReqDTO {
+public class CateGoryClipGetReqDTO {
 	private Long bigCategoryId;
 
 	private Long middleCategoryId;
@@ -12,7 +12,7 @@ public class CateGoryClipStatusGetReqDTO {
 	private Long smallCategoryId;
 
 	@Builder
-	public CateGoryClipStatusGetReqDTO(Long bigCategoryId, Long middleCategoryId, Long smallCategoryId) {
+	public CateGoryClipGetReqDTO(Long bigCategoryId, Long middleCategoryId, Long smallCategoryId) {
 		this.bigCategoryId = bigCategoryId;
 		this.middleCategoryId = middleCategoryId;
 		this.smallCategoryId = smallCategoryId;

--- a/src/main/java/com/comehere/ssgserver/clip/dto/resp/CategoryClipGetInfoRespDTO.java
+++ b/src/main/java/com/comehere/ssgserver/clip/dto/resp/CategoryClipGetInfoRespDTO.java
@@ -1,0 +1,17 @@
+package com.comehere.ssgserver.clip.dto.resp;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CategoryClipGetInfoRespDTO {
+	private Long id;
+
+	private Boolean isCliped;
+
+	@Builder
+	public CategoryClipGetInfoRespDTO(Long id, Boolean isCliped) {
+		this.id = id;
+		this.isCliped = isCliped;
+	}
+}

--- a/src/main/java/com/comehere/ssgserver/clip/infrastructure/CategoryClipRepository.java
+++ b/src/main/java/com/comehere/ssgserver/clip/infrastructure/CategoryClipRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.comehere.ssgserver.clip.domain.CategoryClip;
 
 public interface CategoryClipRepository extends JpaRepository<CategoryClip, Long>, CustomCategoryClipRepository {
-	Boolean existsByUuidAndBigCategoryIdAndMiddleCategoryIdAndSmallCategoryId(UUID uuid, Long bigCategoryId, Long middleCategoryId,
+	Boolean existsByUuidAndBigCategoryIdAndMiddleCategoryIdAndSmallCategoryId(
+			UUID uuid,
+			Long bigCategoryId,
+			Long middleCategoryId,
 			Long smallCategoryId);
 }

--- a/src/main/java/com/comehere/ssgserver/clip/infrastructure/CustomCategoryClipRepository.java
+++ b/src/main/java/com/comehere/ssgserver/clip/infrastructure/CustomCategoryClipRepository.java
@@ -1,13 +1,17 @@
 package com.comehere.ssgserver.clip.infrastructure;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
+import com.comehere.ssgserver.clip.dto.req.CateGoryClipGetReqDTO;
 import com.comehere.ssgserver.clip.dto.req.CategoryClipDeleteReqDTO;
 import com.comehere.ssgserver.clip.dto.resp.CategoryClipGetRespDTO;
 
 public interface CustomCategoryClipRepository {
 	List<CategoryClipGetRespDTO> findCategoryClipGetRespDTOByUuid(UUID uuid);
 
-	void deleteByUuidAndBigCategoryIdAndMiddleCategoryIdAndSmallCategoryId(UUID uuid, CategoryClipDeleteReqDTO dto);
+	Boolean deleteByUuidAndBigCategoryIdAndMiddleCategoryIdAndSmallCategoryId(UUID uuid, CategoryClipDeleteReqDTO dto);
+
+	Optional<Long> findIdByUuidAndBigCategoryIdAndMiddleCategoryIdAndSmallCategoryId(UUID uuid, CateGoryClipGetReqDTO dto);
 }

--- a/src/main/java/com/comehere/ssgserver/clip/infrastructure/CustomCategoryClipRepositoryImpl.java
+++ b/src/main/java/com/comehere/ssgserver/clip/infrastructure/CustomCategoryClipRepositoryImpl.java
@@ -3,8 +3,10 @@ package com.comehere.ssgserver.clip.infrastructure;
 import static com.comehere.ssgserver.clip.domain.QCategoryClip.*;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
+import com.comehere.ssgserver.clip.dto.req.CateGoryClipGetReqDTO;
 import com.comehere.ssgserver.clip.dto.req.CategoryClipDeleteReqDTO;
 import com.comehere.ssgserver.clip.dto.resp.CategoryClipGetRespDTO;
 import com.querydsl.core.types.Projections;
@@ -30,14 +32,26 @@ public class CustomCategoryClipRepositoryImpl implements CustomCategoryClipRepos
 	}
 
 	@Override
-	public void deleteByUuidAndBigCategoryIdAndMiddleCategoryIdAndSmallCategoryId(UUID uuid,
+	public Boolean deleteByUuidAndBigCategoryIdAndMiddleCategoryIdAndSmallCategoryId(UUID uuid,
 			CategoryClipDeleteReqDTO dto) {
-		query.delete(categoryClip)
+		return query.delete(categoryClip)
 				.where(categoryClip.uuid.eq(uuid),
 						bigCategoryIdEq(dto.getBigCategoryId()),
 						middleCategoryIdEq(dto.getMiddleCategoryId()),
 						smallCategoryIdEq(dto.getSmallCategoryId()))
-				.execute();
+				.execute() > 0;
+	}
+
+	@Override
+	public Optional<Long> findIdByUuidAndBigCategoryIdAndMiddleCategoryIdAndSmallCategoryId(UUID uuid,
+			CateGoryClipGetReqDTO dto) {
+		return Optional.ofNullable(query.select(categoryClip.id)
+				.from(categoryClip)
+				.where(categoryClip.uuid.eq(uuid),
+						bigCategoryIdEq(dto.getBigCategoryId()),
+						middleCategoryIdEq(dto.getMiddleCategoryId()),
+						smallCategoryIdEq(dto.getSmallCategoryId()))
+				.fetchOne());
 	}
 
 	private BooleanExpression bigCategoryIdEq(Long bigCategoryId) {

--- a/src/main/java/com/comehere/ssgserver/clip/presentation/CategoryClipController.java
+++ b/src/main/java/com/comehere/ssgserver/clip/presentation/CategoryClipController.java
@@ -13,14 +13,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.comehere.ssgserver.clip.application.CategoryClipService;
-import com.comehere.ssgserver.clip.dto.req.CateGoryClipStatusGetReqDTO;
+import com.comehere.ssgserver.clip.dto.req.CateGoryClipGetReqDTO;
 import com.comehere.ssgserver.clip.dto.req.CategoriesClipDeleteReqDTO;
 import com.comehere.ssgserver.clip.dto.req.CategoryClipCreateReqDTO;
-import com.comehere.ssgserver.clip.dto.req.CategoryClipDeleteReqDTO;
 import com.comehere.ssgserver.clip.vo.req.CategoriesClipDeleteReqVO;
 import com.comehere.ssgserver.clip.vo.req.CategoryClipCreateReqVO;
-import com.comehere.ssgserver.clip.vo.req.CategoryClipDeleteReqVO;
 import com.comehere.ssgserver.clip.vo.resp.CategoriesClipGetRespVO;
+import com.comehere.ssgserver.clip.vo.resp.CategoryClipGetInfoRespVO;
+import com.comehere.ssgserver.clip.vo.resp.CategoryClipGetRespVO;
 import com.comehere.ssgserver.common.response.BaseResponse;
 import com.comehere.ssgserver.common.security.jwt.JWTUtil;
 
@@ -76,7 +76,7 @@ public class CategoryClipController {
 
 	@Operation(summary = "카테고리 좋아요 조회")
 	@GetMapping("/category")
-	public BaseResponse<Boolean> getCategoryClip(
+	public BaseResponse<CategoryClipGetInfoRespVO> getCategoryClip(
 			@RequestParam(value = "bigCategoryId", required = false) Long bigCategoryId,
 			@RequestParam(value = "middleCategoryId", required = false) Long middleCategoryId,
 			@RequestParam(value = "smallCategoryId", required = false) Long smallCategoryId,
@@ -84,12 +84,15 @@ public class CategoryClipController {
 
 		UUID uuid = jwtUtil.getUuidByAuthorization(accessToken);
 
-		CateGoryClipStatusGetReqDTO dto = CateGoryClipStatusGetReqDTO.builder()
+		CateGoryClipGetReqDTO dto = CateGoryClipGetReqDTO.builder()
 				.bigCategoryId(bigCategoryId)
 				.middleCategoryId(middleCategoryId)
 				.smallCategoryId(smallCategoryId)
 				.build();
 
-		return new BaseResponse<>(categoryClipService.getCategoryClipStatus(uuid, dto));
+		return new BaseResponse<>(
+				modelMapper.map(categoryClipService.getCategoryClip(uuid, dto), CategoryClipGetInfoRespVO.class));
 	}
+
+
 }

--- a/src/main/java/com/comehere/ssgserver/clip/vo/resp/CategoryClipGetInfoRespVO.java
+++ b/src/main/java/com/comehere/ssgserver/clip/vo/resp/CategoryClipGetInfoRespVO.java
@@ -1,0 +1,10 @@
+package com.comehere.ssgserver.clip.vo.resp;
+
+import lombok.Getter;
+
+@Getter
+public class CategoryClipGetInfoRespVO {
+	private Long id;
+
+	private Boolean isCliped;
+}

--- a/src/main/java/com/comehere/ssgserver/clip/vo/resp/CategoryClipGetRespVO.java
+++ b/src/main/java/com/comehere/ssgserver/clip/vo/resp/CategoryClipGetRespVO.java
@@ -3,6 +3,7 @@ package com.comehere.ssgserver.clip.vo.resp;
 import lombok.Getter;
 
 @Getter
+
 public class CategoryClipGetRespVO {
 	private Long bigCategoryId;
 

--- a/src/main/java/com/comehere/ssgserver/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/comehere/ssgserver/common/response/BaseResponseStatus.java
@@ -105,7 +105,8 @@ public enum BaseResponseStatus {
 	CLIP_ITEM_ALREADY_ADDED(HttpStatus.BAD_REQUEST, false, 10001, "이미 좋아요한 상품입니다."),
 	CLIP_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, false, 10002, "좋아요한 상품이 아닙니다."),
 	CLIP_CATEGORY_ALREADY_ADDED(HttpStatus.BAD_REQUEST, false, 10003, "이미 좋아요한 카테고리입니다."),
-	CLIP_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, false, 10004, "좋아요한 카테고리가 아닙니다.");
+	CLIP_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, false, 10004, "좋아요한 카테고리가 아닙니다."),
+	CLIP_CATEGORY_NOT_DELETED(HttpStatus.BAD_REQUEST, false, 10005, "카테고리 좋아요 삭제에 실패했습니다.");
 
 	private final HttpStatusCode httpStatusCode;
 	private final boolean isSuccess;


### PR DESCRIPTION
## 📝작업 내용

1. 카테고리 좋아요 삭제 실패 시 예외처리 추가 
<img width="842" alt="image" src="https://github.com/4-ComehereTeam/ssg-server/assets/124120054/62c1429e-c1ff-4030-afab-04eff56112dc">

2. 카테고리 좋아요 단건 조회 시 응답값 카테고리 좋아요 id 추가
<img width="848" alt="image" src="https://github.com/4-ComehereTeam/ssg-server/assets/124120054/05341c68-35c3-435a-b4cc-6bf40f7b14e6">
